### PR TITLE
Added Linked Lists in linear-data-structures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,4 @@
 Gagandeep Singh<singh.23@iitj.ac.in>
 Kartikei Mittal<kartikeimittal@gmail.com>
 Umesh<23umesh.here@gmail.com>
-
+Rohan Singh<singh.77@iitj.ac.in>

--- a/pydatastructs/linear_data_structures/__init__.py
+++ b/pydatastructs/linear_data_structures/__init__.py
@@ -2,10 +2,15 @@ __all__ = []
 
 from . import (
     arrays,
+    linked_lists
 )
 
 from .arrays import (
     OneDimensionalArray,
     DynamicOneDimensionalArray
+)
+
+from .linked_lists import (
+    DoublyLinkedList
 )
 __all__.extend(arrays.__all__)

--- a/pydatastructs/linear_data_structures/linked_lists.py
+++ b/pydatastructs/linear_data_structures/linked_lists.py
@@ -1,5 +1,8 @@
 from __future__ import print_function, division
 from pydatastructs.utils.misc_util import _check_type, NoneType
+from pydatastructs.utils import ( 
+    Node
+)
 
 __author__ = 'rohansingh9001'
 
@@ -8,54 +11,14 @@ __all__ = [
     'LinkedList'
 ]
 
-# A linked list node 
-class Node: 
-
+class LinkedList(object):
     '''
-    Node class for Linked List and Doubly Linked List [ Intended for internal use and not to be imported]
-
-    Parameters
-    ==========
-    
-    For Doubly Linked List use Default constructor(__init__):
-
-        data: type
-            A valid object type.
-            Should be convertible to string using str() method to use print() method on instance
-
-    For Single Linked List use Alternative constructor(singleLink):
-        data: type
-            A valid object type
-            Should be convertible to string using str() method to use print() method on instance
-    
-    Note
-    ====
-
-    classmethod singleLink has been used for Node class for Single linked list due to non existence of a 
-    previous link between the nodes.
+    Abstract class for Linked List in pydatastructs.
     '''
-
-    __slots__ = ['data', 'next', 'prev']
-    
-    # Constructor to create a new node 
-    def __init__(self, data): 
-        self.data = data 
-        self.next = NoneType
-        self.prev = NoneType
-    #Alternative constructor for Single Linked List
-    @classmethod
-    def singleLink(obj, data):
-        obj.data = data
-        obj.next = NoneType
-        return obj
-    
-    def __str__(self):
-        return str(self.data)
-
-'''------------------------Doubly Linked List Class---------------------------'''
+    pass
 
 # Class to create a Doubly Linked List 
-class DoublyLinkedList: 
+class DoublyLinkedList(LinkedList): 
     
 
     '''
@@ -66,90 +29,26 @@ class DoublyLinkedList:
     
     None
 
-    Methods
-    =======
-
-    1) appendleft: 
-        takes parameters - data
-            data: type 
-                A valid object type
-                Should be convertible to string using str() method to use print() method on instance.
-        action - Pushes a new node at the start i.e. left of the DLL.
-
-    2) appendright: 
-        takes parameters - data
-            data: type
-                A valid object type.
-                Should be convertible to string using str() method to use print() method on instance.
-        action - Appends a new node at the end i.e. the right of the DLL.
-    
-    3) insertAfter:
-        takes parameters - prevNode, data
-            prevNode: Node type 
-                An object of Node class 
-            data: type
-                A valid object type.
-                Should be convertible to string using str() method to use print() method in instance.
-        action - Inserts a new node after the prevNode.
-
-    4) insertBefore:
-        takes parameters - nextNode, data
-            prevNode: Node type
-                An object of Node class
-            data: type
-                A valid object type.
-                Should be convertible to string using str() method to use print() method in instance.
-        action - Inserts a new node before the newNode.
-
-    5) insertAt:
-        takes parameters - index, data
-            index: int type
-                An integer i such that 0<= i <= length, where length refers to the length of the List.
-            data: type
-                A valid object type.
-                Should be convertible to string using str() method to use print() method in instance.
-        action - Inserts a new node at the input index.
-
-    6) popleft: 
-        takes parameters - None
-        action - Removes the Node from the left i.e. start of the DLL and returns the data from the Node.
-
-    7) popright:
-        takes parameters - None
-        action - Removes the Node from the right i.e. end of the DLL and returns the data from the Node.
-
-    8) pop:
-        takes parameters - index
-            index: int type
-                An integer i such that 0<= i <= length, where length refers to the length of the List.
-        action - Removes the Node at the index of the DLL and returns the data from the Node.
-    
-    9) __getitem__:
-        takes parameters - index
-            index: int type
-                An integer i such that 0<= i <= length, where length refers to the length of the List.
-        action - Returns the data of the Node at index.
-            
-    10) __setitem__:
-        takes parameters - index, data
-            index: int type
-                An integer i such that 0<= i <= length, where length refers to the length of the List.
-            data: type
-                A valid object type.
-                Should be convertible to string using str() method to use print() method in instance.
-        action - Sets the data of the Node at the index to the input data.
-
-    11) __str__:
-        takes parameters - None
-        action - Prints the DLL in a list from from the start to the end.
-    
-    12) __len__:
-        takes parameters - None
-        action - Returns the length of the DLL.
-
-    13) isEmpty:
-        takes parameters - None
-        action - Return a bool value to check if the DLL is empty or not.
+    Examples
+    ========
+    >>> from pydatastructs import DoublyLinkedLIst as DLL
+    >>> dll = DLL()
+    >>> dll.append(6)
+    >>> arr[0]
+    6
+    >>> dll.head
+    6
+    >>> dll.append(5)
+    >>> dll.appendleft(2)
+    >>> print(dll)
+    [2,6,5]
+    >>> dll[0] = 7.2
+    >>> dll[0]
+    7.2
+    >>> dll.pop(1)
+    6
+    >>> print(dll)
+    [2,5]
 
     References
     ==========
@@ -165,6 +64,15 @@ class DoublyLinkedList:
         self.length = 0
 
     def appendleft(self,data):
+        '''
+        appendleft: 
+        takes parameters - data
+            data: type 
+                A valid object type
+                Should be convertible to string using str() method to 
+                use print() method on instance.
+        action - Pushes a new node at the start i.e. left of the DLL.
+        '''
         self.length += 1
         newNode = Node(data)
         if self.head is not NoneType:
@@ -177,7 +85,16 @@ class DoublyLinkedList:
         if newNode.prev == NoneType:
             self.head = newNode
     
-    def appendright(self, data):
+    def append(self, data):
+        '''
+        append: 
+        takes parameters - data
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to 
+                use print() method on instance.
+        action - Appends a new node at the end i.e. the right of the DLL.
+        '''
         self.length += 1
         newNode = Node(data)
         if self.tail is not NoneType:
@@ -191,6 +108,17 @@ class DoublyLinkedList:
             self.head = newNode
 
     def insertAfter(self, prevNode, data):
+        '''
+        insertAfter:
+        takes parameters - prevNode, data
+            prevNode: Node type 
+                An object of Node class 
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to
+                use print() method in instance.
+        action - Inserts a new node after the prevNode.
+        '''
         self.length += 1
         newNode = Node(data)
         newNode.next = prevNode.next
@@ -203,6 +131,17 @@ class DoublyLinkedList:
             self.head = newNode
     
     def insertBefore(self, nextNode, data):
+        '''
+        insertBefore:
+        takes parameters - nextNode, data
+            prevNode: Node type
+                An object of Node class
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to 
+                use print() method in instance.
+        action - Inserts a new node before the newNode.
+        '''
         self.length += 1
         newNode = Node(data)
         newNode.prev = nextNode.prev
@@ -215,6 +154,18 @@ class DoublyLinkedList:
             self.head = newNode
     
     def insertAt(self, index, data):
+        '''
+        insertAt:
+        takes parameters - index, data
+            index: int type
+                An integer i such that 0<= i <= length, where length 
+                refers to the length of the List.
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to
+                use print() method in instance.
+        action - Inserts a new node at the input index.
+        '''
         if index > self.length or index < 0 or not (_check_type(index, int)):
             raise ValueError('Index input out of range/Index is expected to be an Integer.')
         else:
@@ -241,6 +192,12 @@ class DoublyLinkedList:
                     self.head = newNode
     
     def popleft(self):
+        '''
+        popleft: 
+        takes parameters - None
+        action - Removes the Node from the left i.e. start of the DLL
+         and returns the data from the Node.
+        '''
         self.length -= 1
         oldHead = self.head
         oldHead.next.prev = NoneType
@@ -248,6 +205,12 @@ class DoublyLinkedList:
         return oldHead.data 
 
     def popright(self):
+        '''
+        popright:
+        takes parameters - None
+        action - Removes the Node from the right i.e. end of the DLL 
+        and returns the data from the Node.
+        '''
         self.length -= 1
         oldTail = self.tail
         oldTail.prev.next = NoneType
@@ -255,6 +218,15 @@ class DoublyLinkedList:
         return oldTail.data
 
     def pop(self, index=0):
+        '''
+        pop:
+        takes parameters - index
+            index: int type
+                An integer i such that 0<= i <= length, where length
+                 refers to the length of the List.
+        action - Removes the Node at the index of the DLL and returns
+         the data from the Node.
+        '''
         if index > self.length or index < 0 or not (_check_type(index, int)):
             raise ValueError('Index input out of range/Index is expected to be an Integer.') 
         else:  
@@ -274,6 +246,14 @@ class DoublyLinkedList:
                 return currentNode.data
 
     def __getitem__(self, index): 
+        '''
+        __getitem__:
+        takes parameters - index
+            index: int type
+                An integer i such that 0<= i <= length, where length 
+                refers to the length of the List.
+        action - Returns the data of the Node at index.
+        '''
         if index > self.length or index < 0 or not (_check_type(index, int)):
             raise ValueError('Index input out of range/Index is expected to be an Integer.')
         else:     
@@ -285,6 +265,18 @@ class DoublyLinkedList:
             return currentNode.data
 
     def __setitem__(self, index, data):
+        '''
+        __setitem__:
+        takes parameters - index, data
+            index: int type
+                An integer i such that 0<= i <= length, where length 
+                refers to the length of the List.
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use 
+                print() method in instance.
+        action - Sets the data of the Node at the index to the input data.
+        '''
         if index > self.length or index < 0 or not (_check_type(index, int)):
             raise ValueError('Index input out of range/Index is expected to be an Integer.')
         else:  
@@ -295,8 +287,12 @@ class DoublyLinkedList:
                 counter += 1
             currentNode.data = data
 
-    
     def __str__(self):
+        '''
+        __str__:
+        takes parameters - None
+        action - Prints the DLL in a list from from the start to the end.
+        '''
         elements = []
         currentNode = self.head
         while currentNode is not NoneType:
@@ -305,7 +301,30 @@ class DoublyLinkedList:
         return str(elements)
 
     def __len__(self):
+        '''
+        __len__:
+        takes parameters - None
+        action - Returns the length of the DLL.
+        '''
         return self.length
 
     def isEmpty(self):
+        '''
+        isEmpty:
+        takes parameters - None
+        action - Return a bool value to check if the DLL is empty or not.
+        '''
         return self.length == 0
+
+if __name__ == '__main__':
+    dll = DoublyLinkedList()
+    dll.append(6)
+    arr[0]
+    dll.head
+    dll.append(5)
+    dll.appendleft(2)
+    print(dll)
+    dll[0] = 7.2
+    dll[0]
+    dll.pop(1)
+    print(dll)

--- a/pydatastructs/linear_data_structures/linked_lists.py
+++ b/pydatastructs/linear_data_structures/linked_lists.py
@@ -1,0 +1,311 @@
+from __future__ import print_function, division
+from pydatastructs.utils.misc_util import _check_type, NoneType
+
+__author__ = 'rohansingh9001'
+
+__all__ = [
+    'DoublyLinkedList',
+    'LinkedList'
+]
+
+# A linked list node 
+class Node: 
+
+    '''
+    Node class for Linked List and Doubly Linked List [ Intended for internal use and not to be imported]
+
+    Parameters
+    ==========
+    
+    For Doubly Linked List use Default constructor(__init__):
+
+        data: type
+            A valid object type.
+            Should be convertible to string using str() method to use print() method on instance
+
+    For Single Linked List use Alternative constructor(singleLink):
+        data: type
+            A valid object type
+            Should be convertible to string using str() method to use print() method on instance
+    
+    Note
+    ====
+
+    classmethod singleLink has been used for Node class for Single linked list due to non existence of a 
+    previous link between the nodes.
+    '''
+
+    __slots__ = ['data', 'next', 'prev']
+    
+    # Constructor to create a new node 
+    def __init__(self, data): 
+        self.data = data 
+        self.next = NoneType
+        self.prev = NoneType
+    #Alternative constructor for Single Linked List
+    @classmethod
+    def singleLink(obj, data):
+        obj.data = data
+        obj.next = NoneType
+        return obj
+    
+    def __str__(self):
+        return str(self.data)
+
+'''------------------------Doubly Linked List Class---------------------------'''
+
+# Class to create a Doubly Linked List 
+class DoublyLinkedList: 
+    
+
+    '''
+    A Doubly Linked List Class (abb. DLL)
+    
+    Parameters
+    ==========
+    
+    None
+
+    Methods
+    =======
+
+    1) appendleft: 
+        takes parameters - data
+            data: type 
+                A valid object type
+                Should be convertible to string using str() method to use print() method on instance.
+        action - Pushes a new node at the start i.e. left of the DLL.
+
+    2) appendright: 
+        takes parameters - data
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use print() method on instance.
+        action - Appends a new node at the end i.e. the right of the DLL.
+    
+    3) insertAfter:
+        takes parameters - prevNode, data
+            prevNode: Node type 
+                An object of Node class 
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use print() method in instance.
+        action - Inserts a new node after the prevNode.
+
+    4) insertBefore:
+        takes parameters - nextNode, data
+            prevNode: Node type
+                An object of Node class
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use print() method in instance.
+        action - Inserts a new node before the newNode.
+
+    5) insertAt:
+        takes parameters - index, data
+            index: int type
+                An integer i such that 0<= i <= length, where length refers to the length of the List.
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use print() method in instance.
+        action - Inserts a new node at the input index.
+
+    6) popleft: 
+        takes parameters - None
+        action - Removes the Node from the left i.e. start of the DLL and returns the data from the Node.
+
+    7) popright:
+        takes parameters - None
+        action - Removes the Node from the right i.e. end of the DLL and returns the data from the Node.
+
+    8) pop:
+        takes parameters - index
+            index: int type
+                An integer i such that 0<= i <= length, where length refers to the length of the List.
+        action - Removes the Node at the index of the DLL and returns the data from the Node.
+    
+    9) __getitem__:
+        takes parameters - index
+            index: int type
+                An integer i such that 0<= i <= length, where length refers to the length of the List.
+        action - Returns the data of the Node at index.
+            
+    10) __setitem__:
+        takes parameters - index, data
+            index: int type
+                An integer i such that 0<= i <= length, where length refers to the length of the List.
+            data: type
+                A valid object type.
+                Should be convertible to string using str() method to use print() method in instance.
+        action - Sets the data of the Node at the index to the input data.
+
+    11) __str__:
+        takes parameters - None
+        action - Prints the DLL in a list from from the start to the end.
+    
+    12) __len__:
+        takes parameters - None
+        action - Returns the length of the DLL.
+
+    13) isEmpty:
+        takes parameters - None
+        action - Return a bool value to check if the DLL is empty or not.
+
+    References
+    ==========
+    
+    https://www.geeksforgeeks.org/doubly-linked-list/
+
+    '''
+    __slots__ = ['head','tail','length']
+
+    def __init__(self):
+        self.head = NoneType
+        self.tail = NoneType
+        self.length = 0
+
+    def appendleft(self,data):
+        self.length += 1
+        newNode = Node(data)
+        if self.head is not NoneType:
+            self.head.prev = newNode
+            newNode.next = self.head
+        self.head = newNode
+
+        if newNode.next == NoneType:
+            self.tail = newNode
+        if newNode.prev == NoneType:
+            self.head = newNode
+    
+    def appendright(self, data):
+        self.length += 1
+        newNode = Node(data)
+        if self.tail is not NoneType:
+            self.tail.next = newNode
+            newNode.prev = self.tail
+        self.tail = newNode
+
+        if newNode.next == NoneType:
+            self.tail = newNode
+        if newNode.prev == NoneType:
+            self.head = newNode
+
+    def insertAfter(self, prevNode, data):
+        self.length += 1
+        newNode = Node(data)
+        newNode.next = prevNode.next
+        prevNode.next = newNode
+        newNode.prev = prevNode
+        
+        if newNode.next == NoneType:
+            self.tail = newNode
+        if newNode.prev == NoneType:
+            self.head = newNode
+    
+    def insertBefore(self, nextNode, data):
+        self.length += 1
+        newNode = Node(data)
+        newNode.prev = nextNode.prev
+        nextNode.prev = newNode
+        newNode.next = nextNode
+        
+        if newNode.next == NoneType:
+            self.tail = newNode
+        if newNode.prev == NoneType:
+            self.head = newNode
+    
+    def insertAt(self, index, data):
+        if index > self.length or index < 0 or not (_check_type(index, int)):
+            raise ValueError('Index input out of range/Index is expected to be an Integer.')
+        else:
+            if index == 0:
+                self.appendleft(data)
+            elif index == self.length:
+                self.appendright(data)
+            else:  
+                self.length += 1
+                newNode = Node(data)
+                counter = 0
+                currentNode = self.head
+                while counter != index:
+                    currentNode = currentNode.next
+                    counter += 1
+                currentNode.prev.next = newNode
+                newNode.prev = currentNode.prev
+                currentNode.prev = newNode
+                newNode.next = currentNode
+                    
+                if newNode.next == NoneType:
+                    self.tail = newNode
+                if newNode.prev == NoneType:
+                    self.head = newNode
+    
+    def popleft(self):
+        self.length -= 1
+        oldHead = self.head
+        oldHead.next.prev = NoneType
+        self.head = oldHead.next
+        return oldHead.data 
+
+    def popright(self):
+        self.length -= 1
+        oldTail = self.tail
+        oldTail.prev.next = NoneType
+        self.tail = oldTail.prev
+        return oldTail.data
+
+    def pop(self, index=0):
+        if index > self.length or index < 0 or not (_check_type(index, int)):
+            raise ValueError('Index input out of range/Index is expected to be an Integer.') 
+        else:  
+            if index == 0:
+                self.popleft()
+            elif index == self.length:
+                self.popright()
+            else:
+                self.length -= 1
+                counter = 0
+                currentNode = self.head
+                while counter != index:
+                    currentNode = currentNode.next
+                    counter += 1
+                currentNode.prev.next = currentNode.next
+                currentNode.next.prev = currentNode.prev
+                return currentNode.data
+
+    def __getitem__(self, index): 
+        if index > self.length or index < 0 or not (_check_type(index, int)):
+            raise ValueError('Index input out of range/Index is expected to be an Integer.')
+        else:     
+            counter = 0
+            currentNode = self.head      
+            while counter != index:
+                currentNode = currentNode.next
+                counter += 1
+            return currentNode.data
+
+    def __setitem__(self, index, data):
+        if index > self.length or index < 0 or not (_check_type(index, int)):
+            raise ValueError('Index input out of range/Index is expected to be an Integer.')
+        else:  
+            counter = 0
+            currentNode = self.head    
+            while counter != index:
+                currentNode = currentNode.next
+                counter += 1
+            currentNode.data = data
+
+    
+    def __str__(self):
+        elements = []
+        currentNode = self.head
+        while currentNode is not NoneType:
+            elements.append(currentNode.data)
+            currentNode = currentNode.next
+        return str(elements)
+
+    def __len__(self):
+        return self.length
+
+    def isEmpty(self):
+        return self.length == 0

--- a/pydatastructs/utils/__init__.py
+++ b/pydatastructs/utils/__init__.py
@@ -2,6 +2,7 @@ __all__ = []
 
 from . import misc_util
 from .misc_util import (
-    TreeNode
+    TreeNode,
+    Node
 )
 __all__.extend(misc_util.__all__)

--- a/pydatastructs/utils/misc_util.py
+++ b/pydatastructs/utils/misc_util.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division
 
 __all__ = [
     'TreeNode'
+    'Node'
 ]
 
 _check_type = lambda a, t: isinstance(a, t)
@@ -40,3 +41,48 @@ class TreeNode(object):
         Used for printing.
         """
         return str((self.left, self.key, self.data, self.right))
+
+
+# A linked list node 
+class Node: 
+
+    '''
+    Node class for Linked List and Doubly Linked List [ Intended for internal use and not to be imported]
+
+    Parameters
+    ==========
+    
+    For Doubly Linked List use Default constructor(__init__):
+
+        data: type
+            A valid object type.
+            Should be convertible to string using str() method to use print() method on instance
+
+    For Single Linked List use Alternative constructor(singleLink):
+        data: type
+            A valid object type
+            Should be convertible to string using str() method to use print() method on instance
+    
+    Note
+    ====
+
+    classmethod singleLink has been used for Node class for Single linked list due to non existence of a 
+    previous link between the nodes.
+    '''
+
+    __slots__ = ['data', 'next', 'prev']
+    
+    # Constructor to create a new node 
+    def __new__(self, data): 
+        self.data = data 
+        self.next = NoneType
+        self.prev = NoneType
+    #Alternative constructor for Single Linked List
+    @classmethod
+    def singleLink(obj, data):
+        obj.data = data
+        obj.next = NoneType
+        return obj
+    
+    def __str__(self):
+        return str(self.data)


### PR DESCRIPTION
Added linked-lists.py in linear-data-structures
Contains Doubly Linked List

#### References to other Issues or PRs or Relevant literature
Partially fixes issue #49 which requests to add linked lists.
Only Doubly Linked List added so far Single Linked List remains.

#### Brief description of what is fixed or changed
API for the additions are as follows -

API for Double Linked List:

1)A Doubly linked list should be initialised with `DoubleLinkedList()`

2)Elements can be pushed at the start of the list using `.appendleft(data)`

3)Elements can be appended at the end using `.appendright(data)`

4) can be popped from the list at a certain index by `.pop(index)`

5)`__getitem__` and `__setitem__` support using python syntax,
eg -
`list[1]`
`list[5] =4`

6)Print the Linked List in List form using `print()` function
eg -
if elements in linked list named `sample_list` are 1-2-3-4
`>>>print(sample_list)`
`[1,2,3,4]`

7)Return length of the Linked List using `len()` function.

8)`.popright()` and `.popleft()` pops items from the right and the left respectively.

9)`.insertAt(index, data)` inserts a new Node at the index.

10)`.insertBefore(Node, data)` and `.insertAfter(Node, data)` inserts a new Node before and after the input Node respectively.
