### PR TITLE
heaps.py supports list, tuple and pydatastructs.Array

### DIFF
--- a/pydatastructs/trees/heaps.py
+++ b/pydatastructs/trees/heaps.py
@@ -84,13 +84,10 @@ class DHeap(Heap):
             raise ValueError("%s is invalid heap property"%(heap_property))
         if elements is None:
             elements = DynamicOneDimensionalArray(TreeNode, 0)
-        elif type(elements) in (list,tuple):
-            if not all(map(lambda x: _check_type(x, TreeNode), elements)):
-                raise ValueError("Expected a list/tuple/Array of TreeNode got %s"%(elements))
+        elif _check_type(elements, (list,tuple)):
             elements = DynamicOneDimensionalArray(TreeNode, len(elements), elements)
         elif _check_type(elements, Array):
-            if(not _check_type(elements[0], TreeNode)):
-                raise ValueError(f'Expected a list/tuple/Array of TreeNode got {type(elements[0])}')
+            elements = DynamicOneDimensionalArray(TreeNode, len(elements), elements._data)
         else:
             raise ValueError(f'Expected a list/tuple/Array of TreeNode got {type(elements)}')
         obj.heap = elements

--- a/pydatastructs/trees/heaps.py
+++ b/pydatastructs/trees/heaps.py
@@ -26,7 +26,7 @@ class DHeap(Heap):
 
     elements : list, tuple, Array
         Optional, by default 'None'.
-        List/tuple of initial TreeNode in Heap.
+        list/tuple/Array of initial TreeNode in Heap.
 
 
     heap_property : str

--- a/pydatastructs/trees/heaps.py
+++ b/pydatastructs/trees/heaps.py
@@ -1,6 +1,6 @@
 from pydatastructs.utils.misc_util import _check_type, NoneType, TreeNode, BinomialTreeNode
 from pydatastructs.linear_data_structures.arrays import (ArrayForTrees,
-     DynamicOneDimensionalArray)
+     DynamicOneDimensionalArray, Array)
 from pydatastructs.miscellaneous_data_structures.binomial_trees import BinomialTree
 
 __all__ = [
@@ -24,7 +24,7 @@ class DHeap(Heap):
     Parameters
     ==========
 
-    elements : list, tuple
+    elements : list, tuple, Array
         Optional, by default 'None'.
         List/tuple of initial TreeNode in Heap.
 
@@ -84,9 +84,15 @@ class DHeap(Heap):
             raise ValueError("%s is invalid heap property"%(heap_property))
         if elements is None:
             elements = DynamicOneDimensionalArray(TreeNode, 0)
-        else:
+        elif type(elements) in (list,tuple):
             if not all(map(lambda x: _check_type(x, TreeNode), elements)):
-                raise ValueError("Expect a list/tuple of TreeNode got %s"%(elements))
+                raise ValueError("Expected a list/tuple/Array of TreeNode got %s"%(elements))
+            elements = DynamicOneDimensionalArray(TreeNode, len(elements), elements)
+        elif _check_type(elements, Array):
+            if(not _check_type(elements[0], TreeNode)):
+                raise ValueError(f'Expected a list/tuple/Array of TreeNode got {type(elements[0])}')
+        else:
+            raise ValueError(f'Expected a list/tuple/Array of TreeNode got {type(elements)}')
         obj.heap = elements
         obj._last_pos_filled = obj.heap._last_pos_filled
         obj._build()
@@ -326,7 +332,7 @@ class BinomialHeap(Heap):
     Parameters
     ==========
 
-    root_list: list/tuple
+    root_list: list/tuple/Array
         By default, []
         The list of BinomialTree object references
         in sorted order.
@@ -531,3 +537,7 @@ class BinomialHeap(Heap):
         """
         self.decrease_key(node, self.find_minimum().key - 1)
         self.delete_minimum()
+
+if __name__ == "__main__":
+    from pydatastructs import OneDimensionalArray
+    h = BinaryHeap(OneDimensionalArray(TreeNode,[TreeNode(i,i) for i in range(5)]))

--- a/pydatastructs/trees/heaps.py
+++ b/pydatastructs/trees/heaps.py
@@ -537,7 +537,3 @@ class BinomialHeap(Heap):
         """
         self.decrease_key(node, self.find_minimum().key - 1)
         self.delete_minimum()
-
-if __name__ == "__main__":
-    from pydatastructs import OneDimensionalArray
-    h = BinaryHeap(OneDimensionalArray(TreeNode,[TreeNode(i,i) for i in range(5)]))

--- a/pydatastructs/trees/tests/test_heaps.py
+++ b/pydatastructs/trees/tests/test_heaps.py
@@ -53,13 +53,13 @@ def test_BinaryHeap():
                 TreeNode(1, 1), (2, 2), TreeNode(3, 3),
                 TreeNode(17, 17), TreeNode(19, 19), TreeNode(36, 36)
             ]
-    assert raises(ValueError, lambda:
+    assert raises(TypeError, lambda:
                 BinaryHeap(elements = non_TreeNode_elements, heap_property='min'))
 
     non_TreeNode_elements = DynamicOneDimensionalArray(int, 0)
     non_TreeNode_elements.append(1)
     non_TreeNode_elements.append(2)
-    assert raises(ValueError, lambda:
+    assert raises(TypeError, lambda:
                 BinaryHeap(elements = non_TreeNode_elements, heap_property='min'))
 
     non_heapable = "[1, 2, 3]"

--- a/pydatastructs/trees/tests/test_heaps.py
+++ b/pydatastructs/trees/tests/test_heaps.py
@@ -55,6 +55,17 @@ def test_BinaryHeap():
             ]
     assert raises(ValueError, lambda:
                 BinaryHeap(elements = non_TreeNode_elements, heap_property='min'))
+
+    non_TreeNode_elements = DynamicOneDimensionalArray(int, 0)
+    non_TreeNode_elements.append(1)
+    non_TreeNode_elements.append(2)
+    assert raises(ValueError, lambda:
+                BinaryHeap(elements = non_TreeNode_elements, heap_property='min'))
+
+    non_heapable = "[1, 2, 3]"
+    assert raises(ValueError, lambda:
+                BinaryHeap(elements = non_heapable, heap_property='min'))
+
 def test_TernaryHeap():
     max_heap = TernaryHeap(heap_property="max")
     assert raises(IndexError, lambda: max_heap.extract())

--- a/pydatastructs/trees/tests/test_heaps.py
+++ b/pydatastructs/trees/tests/test_heaps.py
@@ -41,7 +41,7 @@ def test_BinaryHeap():
                 TreeNode(1, 1), TreeNode(2, 2), TreeNode(3, 3),
                 TreeNode(17, 17), TreeNode(19, 19), TreeNode(36, 36)
             ]
-    min_heap = BinaryHeap(elements=DynamicOneDimensionalArray(TreeNode, 9, elements), heap_property="min")
+    min_heap = BinaryHeap(elements=elements, heap_property="min")
     assert min_heap.extract().key == 1
 
     expected_sorted_elements = [2, 3, 7, 17, 19, 25, 36, 100]
@@ -86,7 +86,7 @@ def test_TernaryHeap():
         TreeNode(1, 1), TreeNode(2, 2), TreeNode(3, 3),
         TreeNode(17, 17), TreeNode(19, 19), TreeNode(36, 36)
     ]
-    min_heap = TernaryHeap(elements=DynamicOneDimensionalArray(TreeNode, 9, elements), heap_property="min")
+    min_heap = TernaryHeap(elements=elements, heap_property="min")
     expected_extracted_element = min_heap.heap[0].key
     assert min_heap.extract().key == expected_extracted_element
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Originally in the doctstring it was written that heap expects list/tuple but it was actually taking DODA, so I have made changes to accept list, tuple and Array and derivative objects.

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
