### PR TITLE
Implemeted `Treaps` and `CartesianTree`

### DIFF
--- a/pydatastructs/trees/__init__.py
+++ b/pydatastructs/trees/__init__.py
@@ -12,7 +12,9 @@ from .binary_trees import (
     BinarySearchTree,
     BinaryTreeTraversal,
     AVLTree,
-    BinaryIndexedTree
+    BinaryIndexedTree,
+    CartesianTree,
+    Treap
 )
 __all__.extend(binary_trees.__all__)
 

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -799,7 +799,7 @@ class Treap(CartesianTree):
     References
     ==========
 
-    .. [1] https://en.wikipedia.org/wiki/Binary_search_tree
+    .. [1] https://en.wikipedia.org/wiki/Treap
 
     See Also
     ========

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -677,25 +677,25 @@ class CartesianTree(SelfBalancingBinaryTree):
         node = self.tree[node_idx]
         parent_idx = self.tree[node_idx].parent
         parent = self.tree[parent_idx]
-        while (node.parent != None) and (parent.priority > node.priority):
+        while (node.parent is not None) and (parent.priority > node.priority):
             if parent.right == node_idx:
                 self._left_rotate(parent_idx, node_idx)
             else:
                 self._right_rotate(parent_idx, node_idx)
             node = self.tree[node_idx]
             parent_idx = self.tree[node_idx].parent
-            if parent_idx != None:
+            if parent_idx is not None:
                 parent = self.tree[parent_idx]
-        if node.parent == None:
+        if node.parent is None:
             self.tree[node_idx].is_root = True
 
     def _trickle_down(self, node_idx):
         node = self.tree[node_idx]
         parent_idx = node.parent
-        while node.left != None or node.right != None:
-            if node.left == None:
+        while node.left is not None or node.right is not None:
+            if node.left is None:
                 self._left_rotate(node_idx, self.tree[node_idx].right)
-            elif node.right == None:
+            elif node.right is None:
                 self._right_rotate(node_idx, self.tree[node_idx].left)
             elif self.tree[node.left].priority < self.tree[node.right].priority:
                 self._right_rotate(node_idx, self.tree[node_idx].left)
@@ -720,7 +720,7 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     def delete(self, key, **kwargs):
         node_idx = super(CartesianTree, self).search(key)
-        if node_idx != None:
+        if node_idx is not None:
             self._trickle_down(node_idx)
             return super(CartesianTree, self).delete(key, balancing_info = True)
 

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -683,7 +683,6 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     pydatastructs.trees.binary_tree.SelfBalancingBinaryTree
     """
-
     @classmethod
     def methods(cls):
         return ['__str__', 'insert', 'delete']

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -645,8 +645,8 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     >>> from pydatastructs.trees import CartesianTree as CT
     >>> c = CT()
-    >>> c.insert(1, 1, 4)
-    >>> c.insert(2, 2, 3)
+    >>> c.insert(1, 4, 1)
+    >>> c.insert(2, 3, 2)
     >>> child = c.tree[c.root_idx].left
     >>> c.tree[child].data
     1

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -757,7 +757,6 @@ class CartesianTree(SelfBalancingBinaryTree):
         if node_idx != None:
             self._trickle_down(node_idx)
             return super(CartesianTree, self).delete(key, balancing_info = True)
-        return None
 
     def __str__(self):
         to_be_printed = ['' for i in range(self.tree._last_pos_filled + 1)]

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -1,5 +1,4 @@
-from pydatastructs.utils import TreeNode
-from pydatastructs.utils import CartesianTreeNode
+from pydatastructs.utils import TreeNode, CartesianTreeNode
 from pydatastructs.miscellaneous_data_structures import Stack
 from pydatastructs.linear_data_structures import (
     OneDimensionalArray, DynamicOneDimensionalArray)

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -7,7 +7,6 @@ from collections import deque as Queue
 import random
 from copy import deepcopy
 
-
 __all__ = [
     'AVLTree',
     'BinaryTree',

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -635,9 +635,8 @@ class SelfBalancingBinaryTree(BinarySearchTree):
         kp = self.tree[k].parent
         if kp is None:
             self.root_idx = k
-            
-class CartesianTree(SelfBalancingBinaryTree):
 
+class CartesianTree(SelfBalancingBinaryTree):
     """
     Represents cartesian trees.
 
@@ -674,30 +673,26 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     pydatastructs.trees.binary_tree.SelfBalancingBinaryTree
     """
-    
     def _bubble_up(self, node_idx):
         node = self.tree[node_idx]
         parent_idx = self.tree[node_idx].parent
         parent = self.tree[parent_idx]
         while (node.parent != None) and (parent.priority > node.priority):
             if parent.right == node_idx:
-                self._left_rotate(parent_idx, node_idx) 
-                
+                self._left_rotate(parent_idx, node_idx)
             else:
                 self._right_rotate(parent_idx, node_idx)
-                
-            node = self.tree[node_idx]   
+            node = self.tree[node_idx]
             parent_idx = self.tree[node_idx].parent
             if parent_idx != None:
                 parent = self.tree[parent_idx]
         if node.parent == None:
             self.tree[node_idx].is_root = True
-            
+
     def _trickle_down(self, node_idx):
         node = self.tree[node_idx]
         parent_idx = node.parent
         while node.left != None or node.right != None:
-
             if node.left == None:
                 self._left_rotate(node_idx, self.tree[node_idx].right)
             elif node.right == None:
@@ -706,11 +701,9 @@ class CartesianTree(SelfBalancingBinaryTree):
                 self._right_rotate(node_idx, self.tree[node_idx].left)
             else:
                 self._left_rotate(node_idx, self.tree[node_idx].right)
-                
             node = self.tree[node_idx]
             parent_idx = node.parent
-            
-        
+
     def insert(self, key, data, priority):
         super(CartesianTree, self).insert(key, data)
         node_idx = super(CartesianTree, self).search(key)
@@ -724,7 +717,7 @@ class CartesianTree(SelfBalancingBinaryTree):
             self.tree[node_idx].is_root = True
         else:
             self._bubble_up(node_idx)
-        
+
     def delete(self, key, **kwargs):
         node_idx = super(CartesianTree, self).search(key)
         if node_idx != None:
@@ -738,8 +731,6 @@ class CartesianTree(SelfBalancingBinaryTree):
                 node = self.tree[i]
                 to_be_printed[i] = (node.left, node.key, node.priority, node.data, node.right)
         return str(to_be_printed)
-
-    
 
 class Treap(CartesianTree):
     """
@@ -774,17 +765,14 @@ class Treap(CartesianTree):
     .. [1] https://en.wikipedia.org/wiki/Treap
 
     """
-    
     priorities = set()
-    
     def insert(self, key, data):
         priority = random.random()
         while priority in self.priorities:
             priority = random.random()
         self.priorities.add(priority)
         super(Treap, self).insert(key, data, priority)
-                
-    
+
 class AVLTree(SelfBalancingBinaryTree):
     """
     Represents AVL trees.

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -704,7 +704,7 @@ class CartesianTree(SelfBalancingBinaryTree):
             node = self.tree[node_idx]
             parent_idx = node.parent
 
-    def insert(self, key, data, priority):
+    def insert(self, key, priority, data=None):
         super(CartesianTree, self).insert(key, data)
         node_idx = super(CartesianTree, self).search(key)
         node = self.tree[node_idx]
@@ -764,12 +764,12 @@ class Treap(CartesianTree):
 
     """
     priorities = set()
-    def insert(self, key, data):
+    def insert(self, key, data = None):
         priority = random.random()
         while priority in self.priorities:
             priority = random.random()
         self.priorities.add(priority)
-        super(Treap, self).insert(key, data, priority)
+        super(Treap, self).insert(key, priority, data)
 
 class AVLTree(SelfBalancingBinaryTree):
     """

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -719,10 +719,11 @@ class CartesianTree(SelfBalancingBinaryTree):
             self._bubble_up(node_idx)
 
     def delete(self, key, **kwargs):
+        balancing_info = kwargs.get('balancing_info', False)
         node_idx = super(CartesianTree, self).search(key)
         if node_idx is not None:
             self._trickle_down(node_idx)
-            return super(CartesianTree, self).delete(key, balancing_info = True)
+            return super(CartesianTree, self).delete(key, balancing_info = balancing_info)
 
     def __str__(self):
         to_be_printed = ['' for i in range(self.tree._last_pos_filled + 1)]

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -801,10 +801,6 @@ class Treap(CartesianTree):
 
     .. [1] https://en.wikipedia.org/wiki/Treap
 
-    See Also
-    ========
-
-    pydatastructs.trees.binary_tree.SelfBalancingBinaryTree
     """
     
     priorities = set()

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -683,6 +683,11 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     pydatastructs.trees.binary_tree.SelfBalancingBinaryTree
     """
+
+    @classmethod
+    def methods(cls):
+        return ['__str__', 'insert', 'delete']
+
     def _bubble_up(self, node_idx):
         node = self.tree[node_idx]
         parent_idx = self.tree[node_idx].parent
@@ -701,7 +706,6 @@ class CartesianTree(SelfBalancingBinaryTree):
 
     def _trickle_down(self, node_idx):
         node = self.tree[node_idx]
-        parent_idx = node.parent
         while node.left is not None or node.right is not None:
             if node.left is None:
                 self._left_rotate(node_idx, self.tree[node_idx].right)
@@ -712,7 +716,6 @@ class CartesianTree(SelfBalancingBinaryTree):
             else:
                 self._left_rotate(node_idx, self.tree[node_idx].right)
             node = self.tree[node_idx]
-            parent_idx = node.parent
 
     def insert(self, key, priority, data=None):
         super(CartesianTree, self).insert(key, data)
@@ -773,12 +776,12 @@ class Treap(CartesianTree):
     .. [1] https://en.wikipedia.org/wiki/Treap
 
     """
-    priorities = set()
-    def insert(self, key, data = None):
+    @classmethod
+    def methods(cls):
+        return ['insert']
+
+    def insert(self, key, data=None):
         priority = random.random()
-        while priority in self.priorities:
-            priority = random.random()
-        self.priorities.add(priority)
         super(Treap, self).insert(key, priority, data)
 
 class AVLTree(SelfBalancingBinaryTree):

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -647,7 +647,7 @@ class CartesianTree(SelfBalancingBinaryTree):
     >>> c = CT()
     >>> c.insert(1, 1, 4)
     >>> c.insert(2, 2, 3)
-    >>> child = b.tree[b.root_idx].right
+    >>> child = c.tree[c.root_idx].left
     >>> c.tree[child].data
     1
     >>> c.search(1)
@@ -744,9 +744,6 @@ class Treap(CartesianTree):
     >>> t = T()
     >>> t.insert(1, 1)
     >>> t.insert(2, 2)
-    >>> child = t.tree[b.root_idx].right
-    >>> t.tree[child].data
-    1
     >>> t.search(1)
     0
     >>> t.search(-1) is None

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -770,7 +770,6 @@ class CartesianTree(SelfBalancingBinaryTree):
     
 
 class Treap(CartesianTree):
-
     """
     Represents treaps.
 

--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -667,41 +667,6 @@ class CartesianTree(SelfBalancingBinaryTree):
     pydatastructs.trees.binary_tree.SelfBalancingBinaryTree
     """
     
-    def _left_rotate(self, j, k):
-        y = self.tree[k].left
-        if y is not None:
-            self.tree[y].parent = j
-        self.tree[j].right = y
-        self.tree[k].parent = self.tree[j].parent
-        if self.tree[k].parent is not None:
-            if self.tree[self.tree[k].parent].left == j:
-                self.tree[self.tree[k].parent].left = k
-            else:
-                self.tree[self.tree[k].parent].right = k
-                
-        self.tree[j].parent = k
-        self.tree[k].left = j
-        kp = self.tree[k].parent
-        if kp is None:
-            self.root_idx = k
-            
-    def _right_rotate(self, j, k):
-        y = self.tree[k].right
-        if y is not None:
-            self.tree[y].parent = j
-        self.tree[j].left = y
-        self.tree[k].parent = self.tree[j].parent
-        if self.tree[k].parent is not None:
-            if self.tree[self.tree[k].parent].left == j:
-                self.tree[self.tree[k].parent].left = k
-            else:
-                self.tree[self.tree[k].parent].right = k
-        self.tree[j].parent = k
-        self.tree[k].right = j
-        kp = self.tree[k].parent
-        if kp is None:
-            self.root_idx = k
-
     def _bubble_up(self, node_idx):
         node = self.tree[node_idx]
         parent_idx = self.tree[node_idx].parent

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -305,7 +305,7 @@ def test_AVLTree():
     test_select_rank([2])
     a5.delete(2)
     test_select_rank([])
-    
+
 def test_BinaryIndexedTree():
 
     FT = BinaryIndexedTree

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -360,6 +360,8 @@ def test_CartesianTree():
     assert tree.delete(18) is None
 
 def test_Treap():
+
+    random.seed(0)
     tree = Treap()
     tree.insert(7,7)
     tree.insert(2,2)

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -351,12 +351,12 @@ def test_CartesianTree():
     tree.delete(1.5)
     tree.tree[tree.tree[tree.root_idx].left].key == 1
     tree.delete(8)
-    assert tree.search(8) == None
+    assert tree.search(8) is None
     tree.delete(7)
-    assert tree.search(7) == None
+    assert tree.search(7) is None
     tree.delete(3)
-    assert tree.search(3) == None
-    assert tree.delete(18) == None
+    assert tree.search(3) is None
+    assert tree.delete(18) is None
 
 def test_Treap():
     tree = Treap()
@@ -367,9 +367,9 @@ def test_Treap():
     tree.insert(5,5)
     assert isinstance(tree.tree[0].priority, float)
     tree.delete(1)
-    assert tree.search(1) == None
+    assert tree.search(1) is None
     assert tree.search(2) == 1
-    assert tree.delete(1) == None
+    assert tree.delete(1) is None
 
 def test_issue_234():
     """

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -339,7 +339,7 @@ def test_CartesianTree():
             "(None, 4, 14, 4, None), (6, 9, 17, 9, None), "
             "(7, 7, 22, 7, 8), (None, 6, 42, 6, None), "
             "(None, 8, 49, 8, None), (None, 2, 99, 2, None)]")
-    tree.insert(1.5, 1.5, 4)
+    tree.insert(1.5, 4, 1.5)
     assert str(tree) == \
            ("[(10, 3, 1, 3, 3), (2, 1, 6, 1, None), "
             "(None, 0, 9, 0, None), (4, 5, 11, 5, 5), "

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -363,11 +363,11 @@ def test_Treap():
 
     random.seed(0)
     tree = Treap()
-    tree.insert(7,7)
-    tree.insert(2,2)
-    tree.insert(3,3)
-    tree.insert(4,4)
-    tree.insert(5,5)
+    tree.insert(7, 7)
+    tree.insert(2, 2)
+    tree.insert(3, 3)
+    tree.insert(4, 4)
+    tree.insert(5, 5)
     assert isinstance(tree.tree[0].priority, float)
     tree.delete(1)
     assert tree.search(1) is None

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -319,7 +319,7 @@ def test_BinaryIndexedTree():
     assert t.get_sum(0, 2) == 105
     assert t.get_sum(0, 4) == 114
     assert t.get_sum(1, 9) == 54
-    
+
 def test_CartesianTree():
     tree = CartesianTree()
     tree.insert(3, 3, 1)
@@ -357,7 +357,7 @@ def test_CartesianTree():
     tree.delete(3)
     assert tree.search(3) == None
     assert tree.delete(18) == None
-    
+
 def test_Treap():
     tree = Treap()
     tree.insert(7,7)
@@ -370,7 +370,7 @@ def test_Treap():
     assert tree.search(1) == None
     assert tree.search(2) == 1
     assert tree.delete(1) == None
-    
+
 def test_issue_234():
     """
     https://github.com/codezonediitj/pydatastructs/issues/234

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -323,16 +323,16 @@ def test_BinaryIndexedTree():
 
 def test_CartesianTree():
     tree = CartesianTree()
-    tree.insert(3, 3, 1)
-    tree.insert(1, 1, 6)
-    tree.insert(0, 0, 9)
-    tree.insert(5, 5, 11)
-    tree.insert(4, 4, 14)
-    tree.insert(9, 9, 17)
-    tree.insert(7, 7, 22)
-    tree.insert(6, 6, 42)
-    tree.insert(8, 8, 49)
-    tree.insert(2, 2, 99)
+    tree.insert(3, 1, 3)
+    tree.insert(1, 6, 1)
+    tree.insert(0, 9, 0)
+    tree.insert(5, 11, 5)
+    tree.insert(4, 14, 4)
+    tree.insert(9, 17, 9)
+    tree.insert(7, 22, 7)
+    tree.insert(6, 42, 6)
+    tree.insert(8, 49, 8)
+    tree.insert(2, 99, 2)
     assert str(tree) == \
            ("[(1, 3, 1, 3, 3), (2, 1, 6, 1, 9), "
             "(None, 0, 9, 0, None), (4, 5, 11, 5, 5), "

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -1,6 +1,6 @@
 from pydatastructs.trees.binary_trees import (
     BinarySearchTree, BinaryTreeTraversal, AVLTree,
-    ArrayForTrees, BinaryIndexedTree)
+    ArrayForTrees, BinaryIndexedTree, CartesianTree, Treap)
 from pydatastructs.utils.raises_util import raises
 from pydatastructs.utils.misc_util import TreeNode
 from copy import deepcopy
@@ -305,7 +305,7 @@ def test_AVLTree():
     test_select_rank([2])
     a5.delete(2)
     test_select_rank([])
-
+    
 def test_BinaryIndexedTree():
 
     FT = BinaryIndexedTree
@@ -319,3 +319,54 @@ def test_BinaryIndexedTree():
     assert t.get_sum(0, 2) == 105
     assert t.get_sum(0, 4) == 114
     assert t.get_sum(1, 9) == 54
+    
+def test_CartesianTree():
+    tree = CartesianTree()
+    tree.insert(3, 3, 1)
+    tree.insert(1, 1, 6)
+    tree.insert(0, 0, 9)
+    tree.insert(5, 5, 11)
+    tree.insert(4, 4, 14)
+    tree.insert(9, 9, 17)
+    tree.insert(7, 7, 22)
+    tree.insert(6, 6, 42)
+    tree.insert(8, 8, 49)
+    tree.insert(2, 2, 99)
+    assert str(tree) == \
+           ("[(1, 3, 1, 3, 3), (2, 1, 6, 1, 9), "
+            "(None, 0, 9, 0, None), (4, 5, 11, 5, 5), "
+            "(None, 4, 14, 4, None), (6, 9, 17, 9, None), "
+            "(7, 7, 22, 7, 8), (None, 6, 42, 6, None), "
+            "(None, 8, 49, 8, None), (None, 2, 99, 2, None)]")
+    tree.insert(1.5, 1.5, 4)
+    assert str(tree) == \
+           ("[(10, 3, 1, 3, 3), (2, 1, 6, 1, None), "
+            "(None, 0, 9, 0, None), (4, 5, 11, 5, 5), "
+            "(None, 4, 14, 4, None), (6, 9, 17, 9, None), "
+            "(7, 7, 22, 7, 8), (None, 6, 42, 6, None), "
+            "(None, 8, 49, 8, None), (None, 2, 99, 2, None), "
+            "(1, 1.5, 4, 1.5, 9)]")
+    k = tree.search(1.5)
+    assert tree.tree[tree.tree[k].parent].key == 3
+    tree.delete(1.5)
+    tree.tree[tree.tree[tree.root_idx].left].key == 1
+    tree.delete(8)
+    assert tree.search(8) == None
+    tree.delete(7)
+    assert tree.search(7) == None
+    tree.delete(3)
+    assert tree.search(3) == None
+    assert tree.delete(18) == None
+    
+def test_Treap():
+    tree = Treap()
+    tree.insert(7,7)
+    tree.insert(2,2)
+    tree.insert(3,3)
+    tree.insert(4,4)
+    tree.insert(5,5)
+    assert isinstance(tree.tree[0].priority, float)
+    tree.delete(1)
+    assert tree.search(1) == None
+    assert tree.search(2) == 1
+    assert tree.delete(1) == None

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -4,6 +4,7 @@ from pydatastructs.trees.binary_trees import (
 from pydatastructs.utils.raises_util import raises
 from pydatastructs.utils.misc_util import TreeNode
 from copy import deepcopy
+import random
 
 def test_BinarySearchTree():
     BST = BinarySearchTree

--- a/pydatastructs/utils/__init__.py
+++ b/pydatastructs/utils/__init__.py
@@ -9,6 +9,7 @@ from .misc_util import (
     AdjacencyListGraphNode,
     AdjacencyMatrixGraphNode,
     GraphEdge,
-    Set
+    Set,
+    CartesianTreeNode
 )
 __all__.extend(misc_util.__all__)

--- a/pydatastructs/utils/misc_util.py
+++ b/pydatastructs/utils/misc_util.py
@@ -69,6 +69,7 @@ class CartesianTreeNode(TreeNode):
 
     """
     __slots__ = ['key', 'data', 'priority']
+
     def __new__(cls, key, priority, data=None):
         obj = TreeNode.__new__(cls, key, data)
         obj.priority = priority

--- a/pydatastructs/utils/misc_util.py
+++ b/pydatastructs/utils/misc_util.py
@@ -6,7 +6,8 @@ __all__ = [
     'AdjacencyListGraphNode',
     'AdjacencyMatrixGraphNode',
     'GraphEdge',
-    'Set'
+    'Set',
+    'CartesianTreeNode'
 ]
 
 _check_type = lambda a, t: isinstance(a, t)
@@ -51,6 +52,36 @@ class TreeNode(Node):
         Used for printing.
         """
         return str((self.left, self.key, self.data, self.right))
+
+class CartesianTreeNode(TreeNode):
+    """
+    Represents node in cartesian trees.
+
+    Parameters
+    ==========
+
+    data
+        Any valid data to be stored in the node.
+    key
+        Required for comparison operations.
+    priority: int
+        An integer value for heap property.
+           
+    """
+    __slots__ = ['key', 'data', 'priotity']
+
+    def __new__(cls, key, priority, data=None):
+        obj = TreeNode.__new__(cls, key, data)
+        obj.priority = priority
+        return obj
+
+    def __str__(self):
+        """
+        Used for printing.
+        """
+        return str((self.left, self.key, self.priority, self.data, self.right))
+
+    
 
 class BinomialTreeNode(TreeNode):
     """

--- a/pydatastructs/utils/misc_util.py
+++ b/pydatastructs/utils/misc_util.py
@@ -66,10 +66,9 @@ class CartesianTreeNode(TreeNode):
         Required for comparison operations.
     priority: int
         An integer value for heap property.
-           
-    """
-    __slots__ = ['key', 'data', 'priotity']
 
+    """
+    __slots__ = ['key', 'data', 'priority']
     def __new__(cls, key, priority, data=None):
         obj = TreeNode.__new__(cls, key, data)
         obj.priority = priority
@@ -80,8 +79,6 @@ class CartesianTreeNode(TreeNode):
         Used for printing.
         """
         return str((self.left, self.key, self.priority, self.data, self.right))
-
-    
 
 class BinomialTreeNode(TreeNode):
     """

--- a/pydatastructs/utils/tests/test_code_quality.py
+++ b/pydatastructs/utils/tests/test_code_quality.py
@@ -95,7 +95,8 @@ def _apis():
     pyds.miscellaneous_data_structures.stack.LinkedListStack,
     pyds.DisjointSetForest, pyds.BinomialTree, pyds.TreeNode, pyds.MAryTreeNode,
     pyds.LinkedListNode, pyds.BinomialTreeNode, pyds.AdjacencyListGraphNode,
-    pyds.AdjacencyMatrixGraphNode, pyds.GraphEdge, pyds.Set, pyds.BinaryIndexedTree]
+    pyds.AdjacencyMatrixGraphNode, pyds.GraphEdge, pyds.Set, pyds.BinaryIndexedTree,
+    pyds.CartesianTree, pyds.CartesianTreeNode, pyds.Treap]
 
 def test_public_api():
     pyds = pydatastructs

--- a/pydatastructs/utils/tests/test_misc_util.py
+++ b/pydatastructs/utils/tests/test_misc_util.py
@@ -1,5 +1,5 @@
 from pydatastructs.utils import (AdjacencyListGraphNode, AdjacencyMatrixGraphNode,
-                                GraphEdge, BinomialTreeNode, MAryTreeNode)
+                                GraphEdge, BinomialTreeNode, MAryTreeNode, CartesianTreeNode)
 from pydatastructs.utils.raises_util import raises
 
 def test_AdjacencyListGraphNode():

--- a/pydatastructs/utils/tests/test_misc_util.py
+++ b/pydatastructs/utils/tests/test_misc_util.py
@@ -38,3 +38,7 @@ def test_MAryTreeNode():
     m.add_children(*[i for i in range(2,10)])
     assert str(m) == "(1, 1)"
     assert str(m.children) == "['2', '3', '4', '5', '6', '7', '8', '9']"
+
+def test_CartesianTreeNode():
+    c = CartesianTreeNode(1,1,1)
+    assert str(c) == "(None, 1, 1, 1, None)"

--- a/pydatastructs/utils/tests/test_misc_util.py
+++ b/pydatastructs/utils/tests/test_misc_util.py
@@ -40,5 +40,5 @@ def test_MAryTreeNode():
     assert str(m.children) == "['2', '3', '4', '5', '6', '7', '8', '9']"
 
 def test_CartesianTreeNode():
-    c = CartesianTreeNode(1,1,1)
+    c = CartesianTreeNode(1, 1, 1)
     assert str(c) == "(None, 1, 1, 1, None)"


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #215" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->
Closes #215
Closes #106 


#### Brief description of what is fixed or changed
##### Implemented CartesianTree
In `insert` method, it required an additional parameter, `priority` compared to the `insert` method of `BinarySearchTree`.
The `insert` method calls the insert of parent class i.e `BinarySearchTree`, then searches for the key, and converts the `TreeNode` inserted in `tree`, which is `ArrayForTrees`, to `CartesianTreeNode` and then do the rotations to satisfy heap property.
The `delete` method does the rotations first, to make the node a leaf and then calls the delete method of the parent class.

##### Implemented Treap
In `insert` method, it generates a priority which is not already generated before by maintaining a set by the name of `priorities`, and the calls the `insert` method of the parent class with `priority` as random number generated.

#### Other comments
Implemented `_left_rotate` and `_right_rotate` methods in `CartesianTree` because of Issue #234
