### PR TITLE
Fixed _left_rotate and _right_rotate

### DIFF
--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -563,7 +563,10 @@ class SelfBalancingBinaryTree(BinarySearchTree):
         self.tree[j].left = y
         self.tree[k].parent = self.tree[j].parent
         if self.tree[k].parent is not None:
-            self.tree[self.tree[k].parent].left = k
+            if self.tree[self.tree[k].parent].left == j:
+                self.tree[self.tree[k].parent].left = k
+            else:
+                self.tree[self.tree[k].parent].right = k
         self.tree[j].parent = k
         self.tree[k].right = j
         kp = self.tree[k].parent
@@ -617,7 +620,10 @@ class SelfBalancingBinaryTree(BinarySearchTree):
         self.tree[j].right = y
         self.tree[k].parent = self.tree[j].parent
         if self.tree[k].parent is not None:
-            self.tree[self.tree[k].parent].right = k
+            if self.tree[self.tree[k].parent].left == j:
+                self.tree[self.tree[k].parent].left = k
+            else:
+                self.tree[self.tree[k].parent].right = k
         self.tree[j].parent = k
         self.tree[k].left = j
         kp = self.tree[k].parent

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -344,3 +344,7 @@ def test_issue_234():
     assert tree.tree[tree.tree[3].parent].right == 3
     tree._left_rotate(5,3)
     assert str(tree) == original_tree
+    tree.insert(4.54, 4.54)
+    tree.insert(4.56, 4.56)
+    tree._left_rotate(5, 8)
+    assert tree.tree[tree.tree[8].parent].left == 8

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -332,11 +332,15 @@ def test_issue_234():
     tree.insert(4.4, 4.4)
     tree.insert(4.55, 4.55)
     tree.insert(4.65, 4.65)
+    original_tree = str(tree)
     tree._right_rotate(3, 5)
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
+    assert tree.tree[tree.tree[5].parent].right == 5
     assert str(tree) == ("[(2, 5, 5, 1), (None, 5.5, 5.5, None), "
                          "(4, 4.5, 4.5, 5), (None, 4.6, 4.6, 6), "
                          "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
                          "(None, 4.65, 4.65, None)]")
     assert tree.tree[tree.tree[3].parent].right == 3
+    tree._left_rotate(5,3)
+    assert str(tree) == original_tree

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -325,10 +325,10 @@ def test_issue_234():
     https://github.com/codezonediitj/pydatastructs/issues/234
     """
     tree = SelfBalancingBinaryTree()
-    tree.insert(5,5)
-    tree.insert(5.5,5.5)
-    tree.insert(4.5,4.5)
-    tree.insert(4.6,4.6)
+    tree.insert(5, 5)
+    tree.insert(5.5, 5.5)
+    tree.insert(4.5, 4.5)
+    tree.insert(4.6, 4.6)
     tree.insert(4.4, 4.4)
     tree.insert(4.55, 4.55)
     tree.insert(4.65, 4.65)
@@ -341,3 +341,4 @@ def test_issue_234():
                          "(4, 4.5, 4.5, 5), (None, 4.6, 4.6, 6), "
                          "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
                          "(None, 4.65, 4.65, None)]")
+    assert tree.tree[tree.tree[3].parent].right == 3

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -337,3 +337,7 @@ def test_issue_234():
     
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
+    assert str(tree) == ("[(2, 5, 5, 1), (None, 5.5, 5.5, None), "
+                         "(4, 4.5, 4.5, 5), (None, 4.6, 4.6, 6), "
+                         "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
+                         "(None, 4.65, 4.65, None)]")

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -332,11 +332,8 @@ def test_issue_234():
     tree.insert(4.4, 4.4)
     tree.insert(4.55, 4.55)
     tree.insert(4.65, 4.65)
-
     
     tree._right_rotate(3, 5)
     
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
-    		 
-

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -325,10 +325,10 @@ def test_issue_234():
     https://github.com/codezonediitj/pydatastructs/issues/234
     """
     tree = SelfBalancingBinaryTree()
-    tree.insert(5, 5)
-    tree.insert(5.5, 5.5)
-    tree.insert(4.5, 4.5)
-    tree.insert(4.6, 4.6)
+    tree.insert(5,5)
+    tree.insert(5.5,5.5)
+    tree.insert(4.5,4.5)
+    tree.insert(4.6,4.6)
     tree.insert(4.4, 4.4)
     tree.insert(4.55, 4.55)
     tree.insert(4.65, 4.65)
@@ -337,11 +337,7 @@ def test_issue_234():
     
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
-    
-   
     assert str(tree) == ("[(2, 5, 5, 1), (None, 5.5, 5.5, None), "
                          "(4, 4.5, 4.5, 5), (None, 4.6, 4.6, 6), "
                          "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
                          "(None, 4.65, 4.65, None)]")
-
-    assert tree.tree[tree.tree[3].parent].right == 3

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -342,7 +342,7 @@ def test_issue_234():
                          "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
                          "(None, 4.65, 4.65, None)]")
     assert tree.tree[tree.tree[3].parent].right == 3
-    tree._left_rotate(5,3)
+    tree._left_rotate(5, 3)
     assert str(tree) == original_tree
     tree.insert(4.54, 4.54)
     tree.insert(4.56, 4.56)

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -1,6 +1,6 @@
 from pydatastructs.trees.binary_trees import (
     BinarySearchTree, BinaryTreeTraversal, AVLTree,
-    ArrayForTrees, BinaryIndexedTree)
+    ArrayForTrees, BinaryIndexedTree, SelfBalancingBinaryTree)
 from pydatastructs.utils.raises_util import raises
 from pydatastructs.utils.misc_util import TreeNode
 from copy import deepcopy
@@ -319,3 +319,24 @@ def test_BinaryIndexedTree():
     assert t.get_sum(0, 2) == 105
     assert t.get_sum(0, 4) == 114
     assert t.get_sum(1, 9) == 54
+
+def test_issue_234():
+    """
+    https://github.com/codezonediitj/pydatastructs/issues/234
+    """
+    tree = SelfBalancingBinaryTree() 
+    tree.insert(5,5)
+    tree.insert(5.5,5.5)
+    tree.insert(4.5,4.5)
+    tree.insert(4.6,4.6)
+    tree.insert(4.4, 4.4)
+    tree.insert(4.55, 4.55)
+    tree.insert(4.65, 4.65)
+
+    
+    tree._right_rotate(3, 5)
+    
+    assert tree.tree[3].parent == 5
+    assert tree.tree[2].right != 3
+    		 
+

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -332,9 +332,7 @@ def test_issue_234():
     tree.insert(4.4, 4.4)
     tree.insert(4.55, 4.55)
     tree.insert(4.65, 4.65)
-    
     tree._right_rotate(3, 5)
-    
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
     assert str(tree) == ("[(2, 5, 5, 1), (None, 5.5, 5.5, None), "

--- a/pydatastructs/trees/tests/test_binary_trees.py
+++ b/pydatastructs/trees/tests/test_binary_trees.py
@@ -337,7 +337,11 @@ def test_issue_234():
     
     assert tree.tree[3].parent == 5
     assert tree.tree[2].right != 3
+    
+   
     assert str(tree) == ("[(2, 5, 5, 1), (None, 5.5, 5.5, None), "
                          "(4, 4.5, 4.5, 5), (None, 4.6, 4.6, 6), "
                          "(None, 4.4, 4.4, None), (None, 4.55, 4.55, 3), "
                          "(None, 4.65, 4.65, None)]")
+
+    assert tree.tree[tree.tree[3].parent].right == 3


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
Fixes #234

#### Brief description of what is fixed or changed
Removed assumption rotates were making for parent of `j`.

#### Other comments
See Issue #234