### PR TITLE
Fixed issue with `insert` in `BinarySearchTree`

### DIFF
--- a/pydatastructs/trees/binary_trees.py
+++ b/pydatastructs/trees/binary_trees.py
@@ -218,7 +218,7 @@ class BinarySearchTree(BinaryTree):
             self.tree[walk].key = key
             self.tree[walk].data = data
             return None
-        new_node, prev_node, flag = TreeNode(key, data), 0, True
+        new_node, prev_node, flag = TreeNode(key, data), self.root_idx, True
         while flag:
             if not self.comparator(key, self.tree[walk].key):
                 if self.tree[walk].right is None:


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->
See https://github.com/codezonediitj/pydatastructs/pull/235#issuecomment-616184252 of PR #235 

#### Brief description of what is fixed or changed
`insert` in `BinarySearchTree` assumes root as `0` and starts with `0` by initializing `prev_node` as shown below:
https://github.com/codezonediitj/pydatastructs/blob/4452dc8ad82db581f528e01f3cdc6a018ce76453/pydatastructs/trees/binary_trees.py#L221.

However, this is not a case if the tree is rotated, root can be changed from 0.

