### PR TITLE
Added `make_root` in DSU 

### DIFF
--- a/pydatastructs/miscellaneous_data_structures/disjoint_set.py
+++ b/pydatastructs/miscellaneous_data_structures/disjoint_set.py
@@ -16,6 +16,9 @@ class DisjointSetForest(object):
     >>> dst.union(1, 2)
     >>> dst.find_root(2).key
     1
+    >>> dst.make_root(2)
+    >>> dst.find_root(2).key
+    2
 
     References
     ==========
@@ -74,3 +77,18 @@ class DisjointSetForest(object):
 
             y_root.parent = x_root
             x_root.size += y_root.size
+
+    def make_root(self, key):
+        """
+        Finds the set to which the key belongs
+        and makes it as the root of the set.
+        """
+        if self.tree.get(key, None) is None:
+            raise KeyError("Invalid key, %s"%(key))
+
+        current_root = self.find_root(key)
+        if current_root.key != key:
+            key_set = self.tree[key]
+            current_root.parent = key_set
+            key_set.size = current_root.size
+            key_set.parent = key_set

--- a/pydatastructs/miscellaneous_data_structures/disjoint_set.py
+++ b/pydatastructs/miscellaneous_data_structures/disjoint_set.py
@@ -86,9 +86,20 @@ class DisjointSetForest(object):
         if self.tree.get(key, None) is None:
             raise KeyError("Invalid key, %s"%(key))
 
-        current_root = self.find_root(key)
-        if current_root.key != key:
-            key_set = self.tree[key]
-            current_root.parent = key_set
-            key_set.size = current_root.size
+        key_set = self.tree[key]
+        if key_set.parent is not key_set:
+            current_parent = key_set.parent
+            # Remove this key subtree size from all its ancestors
+            while current_parent.parent is not current_parent:
+                current_parent.size -= key_set.size
+                current_parent = current_parent.parent
+
+            all_set_size = current_parent.size # This is the root node
+            current_parent.size -= key_set.size
+
+            # Make parent of current root as key
+            current_parent.parent = key_set
+            # size of new root will be same as previous root's size
+            key_set.size = all_set_size
+            # Make parent of key as itself
             key_set.parent = key_set

--- a/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
+++ b/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
@@ -15,9 +15,15 @@ def test_DisjointSetForest():
 
     assert (dst.find_root(1) == dst.find_root(2) ==
             dst.find_root(5) == dst.find_root(6) == dst.find_root(8))
+    assert dst.find_root(1).key == 1
+    assert dst.find_root(2).key == 1
+    dst.make_root(8)
+    assert dst.find_root(2).key == 8
+    assert dst.find_root(8).key == 8
     assert dst.find_root(3) == dst.find_root(4)
     assert dst.find_root(7).key == 7
-
+    dst.make_root(2)
     assert raises(KeyError, lambda: dst.find_root(9))
+    assert raises(KeyError, lambda: dst.make_root(19))
     dst.union(3, 1)
-    assert dst.find_root(3).key == 1
+    assert dst.find_root(3).key == 2

--- a/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
+++ b/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
@@ -29,3 +29,36 @@ def test_DisjointSetForest():
     assert dst.find_root(1).key == 5
     assert dst.find_root(5).key == 5
     assert raises(KeyError, lambda: dst.make_root(9))
+
+    dst = DisjointSetForest()
+    for i in range(6):
+        dst.make_set(i)
+    assert dst.tree[2].size == 1
+    dst.union(2, 3)
+    assert dst.tree[2].size == 2
+    assert dst.tree[3].size == 1
+    dst.union(1, 4)
+    dst.union(2, 4)
+    # current tree
+    ###############
+    #       2
+    #      / \
+    #     1   3
+    #    /
+    #   4
+    ###############
+    assert dst.tree[2].size == 4
+    assert dst.tree[1].size == 2
+    assert dst.tree[3].size == dst.tree[4].size == 1
+    dst.make_root(4)
+    # New tree
+    ###############
+    #       4
+    #       |
+    #       2
+    #      / \
+    #     1   3
+    ###############
+    assert dst.tree[4].size == 4
+    assert dst.tree[2].size == 3
+    assert dst.tree[1].size == dst.tree[3].size == 1

--- a/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
+++ b/pydatastructs/miscellaneous_data_structures/tests/test_disjoint_set.py
@@ -15,15 +15,17 @@ def test_DisjointSetForest():
 
     assert (dst.find_root(1) == dst.find_root(2) ==
             dst.find_root(5) == dst.find_root(6) == dst.find_root(8))
-    assert dst.find_root(1).key == 1
-    assert dst.find_root(2).key == 1
-    dst.make_root(8)
-    assert dst.find_root(2).key == 8
-    assert dst.find_root(8).key == 8
     assert dst.find_root(3) == dst.find_root(4)
     assert dst.find_root(7).key == 7
-    dst.make_root(2)
+
     assert raises(KeyError, lambda: dst.find_root(9))
-    assert raises(KeyError, lambda: dst.make_root(19))
     dst.union(3, 1)
-    assert dst.find_root(3).key == 2
+    assert dst.find_root(3).key == 1
+    assert dst.find_root(5).key == 1
+    dst.make_root(6)
+    assert dst.find_root(3).key == 6
+    assert dst.find_root(5).key == 6
+    dst.make_root(5)
+    assert dst.find_root(1).key == 5
+    assert dst.find_root(5).key == 5
+    assert raises(KeyError, lambda: dst.make_root(9))


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
Added a method to modify the parent of set to which `key` belongs

```py
>>> dst = DisjointSetForest()
>>> dst.make_set(1)
>>> dst.make_set(2)
>>> dst.union(1, 2)
>>> dst.find_root(2).key
1
>>> dst.make_root(2)
>>> dst.find_root(2).key
2
```
