### PR TITLE
Lowest common ancestor added

### DIFF
--- a/pydatastructs/graphs/__init__.py
+++ b/pydatastructs/graphs/__init__.py
@@ -17,7 +17,8 @@ from .algorithms import (
     shortest_paths,
     all_pair_shortest_paths,
     topological_sort,
-    topological_sort_parallel
+    topological_sort_parallel,
+    lowest_common_ancestor
 )
 
 __all__.extend(algorithms.__all__)

--- a/pydatastructs/graphs/tests/test_algorithms.py
+++ b/pydatastructs/graphs/tests/test_algorithms.py
@@ -1,8 +1,10 @@
+from math import exp
+from pydatastructs.graphs.algorithms import lowest_common_ancestor
 from pydatastructs import (breadth_first_search, Graph,
 breadth_first_search_parallel, minimum_spanning_tree,
 minimum_spanning_tree_parallel, strongly_connected_components,
 depth_first_search, shortest_paths, topological_sort,
-topological_sort_parallel)
+topological_sort_parallel, lowest_common_ancestor)
 from pydatastructs.utils.raises_util import raises
 
 def test_breadth_first_search():
@@ -369,3 +371,42 @@ def test_topological_sort():
 
     _test_topological_sort(topological_sort, "List", "kahn")
     _test_topological_sort(topological_sort_parallel, "List", "kahn", 3)
+
+def test_lowest_common_ancestor():
+    def _test_lowest_common_ancestor(ds):
+        import pydatastructs.utils.misc_util as utils
+        GraphNode = getattr(utils, "Adjacency" + ds + "GraphNode")
+
+        V1 = GraphNode(0)
+        V2 = GraphNode(1)
+        V3 = GraphNode(2)
+        V4 = GraphNode(3)
+        V5 = GraphNode(4)
+        V6 = GraphNode(5)
+        V7 = GraphNode(6)
+
+        G1 = Graph(V1, V2, V3, V4, V5, V6, V7)
+
+        edges = [
+            (V1.name, V2.name),
+            (V1.name, V3.name),
+            (V3.name, V4.name),
+            (V3.name, V5.name),
+            (V5.name, V6.name),
+            (V5.name, V7.name)
+        ]
+
+        for edge in edges:
+            G1.add_edge(*edge)
+
+        lca = lowest_common_ancestor(G1, V6.name, V7.name)
+        expected_result = V5.name
+        assert(lca == expected_result)
+
+        lca2 = lowest_common_ancestor(G1, V4.name, V7.name)
+        expected_result = V3.name
+        assert(lca2 == expected_result)
+
+        lca3 = lowest_common_ancestor(G1, V2.name, V7.name)
+        expected_result = V1.name
+        assert(lca3 == expected_result)


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Added the lowest_common_ancestor method that returns the lowest common ancestor of two given vertices in a graph (an ancestor that is common to both vertices and farthest from the root vertex).
#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
