### PR TITLE
Do not invoke setupy.py directly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ Installation
 You can install the library by running the following command,
 
 ```python
-python3 setup.py install
+python -m pip install .
 ```
 
 For development purposes, you can use the option `develop` as shown below,
 
 ```python
-python3 setup.py develop
+python -m pip install -e .
 ```
 
 Make sure that your python version is above `3.5`.


### PR DESCRIPTION
invoking setup.py directly is not the best way to install a package from
source. See one of the most recent blog about this:

https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

This updates the readme to invoke pip, and use `python -m pip` to make
sure that the pip which is invoked is the one from the current Python.

i'm also happy to make it `python3 -m pip`, but these days python points
to python 3 most of the time.

<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
