### PR TITLE
Fix typo in docstring of `arrays.OneDimensionalArray`

### DIFF
--- a/pydatastructs/linear_data_structures/arrays.py
+++ b/pydatastructs/linear_data_structures/arrays.py
@@ -31,7 +31,7 @@ class OneDimensionalArray(Array):
         The elements in the array, all should
         be of same type.
     init: a python type
-        The inital value with which the element has
+        The initial value with which the element has
         to be initialized. By default none, used only
         when the data is not given.
     backend: pydatastructs.Backend


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed


#### Other comments
