### PR TITLE
Fix tiny bug in misc_util.py

### DIFF
--- a/pydatastructs/utils/misc_util.py
+++ b/pydatastructs/utils/misc_util.py
@@ -29,7 +29,7 @@ class Backend(Enum):
         return self.value
 
 def raise_if_backend_is_not_python(api, backend):
-    if backend != Backend.PYTHON:
+    if backend != str(Backend.PYTHON):
         raise ValueError("As of {} version, only {} backend is supported for {} API".format(
                             pydatastructs.__version__, str(Backend.PYTHON), api))
 


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->

#### References to other Issues or PRs or Relevant literature
<!-- If this pull request fixes an issue, write "Fixes #NNNN" in that exact
format, e.g. "Fixes #1234". See
https://github.com/blog/1506-closing-issues-via-pull-requests
Please also write a comment on that issue linking back to this pull request once it is
open. -->


#### Brief description of what is fixed or changed
When I run the following code, the program won't work correctly:

```
>>> from pydatastructs import OneDimensionalArray
>>> from pydatastructs import OneDimensionalArray as ODA
>>> ODA(int, 5, backend='Python')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/yuhaoq/yuhaoq/noob/pydatastructs/pydatastructs/linear_data_structures/arrays.py", line 78, in __new__
    raise_if_backend_is_not_python(
  File "/Users/yuhaoq/yuhaoq/noob/pydatastructs/pydatastructs/utils/misc_util.py", line 33, in raise_if_backend_is_not_python
    raise ValueError("As of {} version, only {} backend is supported for {} API".format(
ValueError: As of 1.0.1-dev version, only Python backend is supported for <class 'pydatastructs.linear_data_structures.arrays.OneDimensionalArray'> API

```

I figured out the reason behind is that in `raise_if_backend_is_not_python`, the type of `backend` is `str`, but the type of `Backend.Python` is `Backend`. So in order to solve it, we should convert the type of `Backend.Python`  to `str`

#### Other comments
