### PR TITLE
BST insert(), search() working

### DIFF
--- a/BST_module.cpp
+++ b/BST_module.cpp
@@ -1,0 +1,291 @@
+//
+//  BST_module.c
+//  BST
+//
+//  Created by dwd on 12/27/17.
+//  Copyright © 2017 holdendou. All rights reserved.
+//
+
+#include "BST_module.hpp"
+
+/*
+ * constructors/destructors
+*/
+static void BSTDealloc(BST* self) {
+    if ((PyObject*)self == Py_None) { // base case
+        Py_DECREF(Py_None);
+        return;
+    }
+    
+    // post-order traversal to dealloc descentents
+    BSTDealloc((BST*)self->left);
+    BSTDealloc((BST*)self->right);
+    
+    Py_XDECREF(self->key);
+    Py_XDECREF(self->data);
+    Py_TYPE(self)->tp_free((PyObject*)self);
+    
+}
+
+static PyObject* BSTAlloc(PyTypeObject *type, PyObject *args, PyObject *kwds) {
+    BST * self = (BST*)type->tp_alloc(type, 0);
+    
+    // set all three as None
+    if (self) {
+        Py_INCREF(Py_None);
+        Py_INCREF(Py_None);
+        Py_INCREF(Py_None);
+        Py_INCREF(Py_None);
+        self->key = Py_None;
+        self->data = Py_None;
+        self->left = Py_None;
+        self->right = Py_None;
+    }
+    
+    return (PyObject*)self;
+}
+
+static int BSTInit(BST* self, PyObject *args, PyObject *kwds) {
+    char * kwlist[] = {"key","data", NULL};
+    PyObject* key = NULL;
+    PyObject* data = NULL;
+    
+    if (!PyArg_ParseTupleAndKeywords(args, kwds, "OO", kwlist, &key, &data)) {
+        return -1;
+    }
+
+    if (key) {
+        Py_INCREF(key);        
+        PyObject* tmp = self->key;
+        self->key = key;
+        Py_XDECREF(tmp);
+    }
+
+    if (data) {
+        Py_INCREF(data);        
+        PyObject* tmp = self->data;
+        self->data = data;
+        Py_XDECREF(tmp);
+    }
+    
+    return 0;
+    
+}
+
+static PyTypeObject BSTType = {
+    PyVarObject_HEAD_INIT(NULL, 0)
+    "BST.BST", // name
+    sizeof(BST), // size
+    0, // itemsize
+    (destructor)BSTDealloc,
+    0,0,0,0,0,0,0,0,0,0,0,0,0,0,
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,
+    "BST type object",
+    0, 0, 0, 0, 0, 0,
+    BSTMethods,
+    BSTMembers,
+    0,0,0,0,0,0,
+    (initproc)BSTInit,
+    0,
+    BSTAlloc
+};
+
+/**
+ * methods
+*/
+static int inorder(BST* self, PyObject* list) {
+    if ((PyObject*)self == Py_None) {
+        return 0;
+    }
+
+    int sts = inorder((BST*)self->left, list);
+    if (sts < 0) {
+        return -1;
+    }
+    sts = PyList_Append(list, self->data);
+    if (sts < 0) {
+        return -1;
+    }
+    sts = inorder((BST*)self->right, list);
+    if (sts < 0) {
+        return -1;
+    }
+    return sts;
+}
+static PyObject* BSTListify(BST* self) {
+    PyObject* inorder_list = PyList_New(0);
+    if (inorder_list) {
+        int sts = inorder(self, inorder_list);
+        if (sts < 0) {
+            PyErr_SetString(PyExc_AttributeError, "inorder");
+            return NULL;
+        }
+    }
+    return inorder_list;
+}
+
+static PyObject* BSTSearch(BST* self, PyObject* args) {
+    PyObject *key = NULL;
+    if (!PyArg_ParseTuple(args, "O", &key)) {
+        return NULL;
+    }
+
+
+    if ((PyObject*)self == Py_None) {
+        Py_INCREF(Py_False);
+        return Py_False;
+    }
+
+    if (self->key > key) { // curr elem is larger; insert left
+        return BSTSearch((BST*)self->left, args);
+    } else if(self->key == key) {
+        Py_INCREF(Py_True);
+        return Py_True;
+    } else {
+        return BSTSearch((BST*)self->right, args);
+    }
+    Py_INCREF(self);
+    return (PyObject*)self;
+}
+
+
+static PyObject* BSTInsert(BST* self, PyObject* args, PyObject* kwargs) {
+    static char* keywords[] = {"key", "data", "comparator", NULL};
+    PyObject *data = NULL, *key = NULL, *comparator = NULL;
+    
+    if (!PyArg_ParseTupleAndKeywords(args, kwargs, "OO|O", keywords, &key, &data, &comparator)) {
+        return NULL;
+    }
+
+    if ((PyObject*)self == Py_None) {
+        BST * b = (BST*)BSTAlloc(&BSTType, NULL, NULL);
+        PyObject* argument = Py_BuildValue("(OO)", key, data);
+        BSTInit(b, argument, NULL);
+        Py_DECREF(argument);
+        return (PyObject*)b;
+    }    
+    
+    if (comparator == NULL) {
+        PyObject* tmp;
+        if (self->key > key) { // curr key is larger; insert left
+            tmp = self->left;
+            self->left = BSTInsert((BST*)self->left, args, kwargs);
+            Py_DECREF(tmp);
+        } else if(self->key == key) {
+            self->data = data;
+        } else {
+            tmp = self->right;
+            self->right = BSTInsert((BST*)self->right, args, kwargs);
+            Py_DECREF(tmp);
+        }
+        
+        Py_INCREF(self);
+        return (PyObject*)self;
+    } else {
+        // Check if the provided comparator is callable
+        if (!PyCallable_Check(comparator)) {
+            PyErr_SetString(PyExc_ValueError, "comparator should be callable");
+            return NULL;
+        }
+
+        PyObject* arguments = Py_BuildValue("OO", self->key, key);
+        PyObject* comp = PyObject_CallObject(comparator, arguments);
+        Py_DECREF(arguments);
+        
+        if (!PyLong_Check(comp)) {
+            PyErr_SetString(PyExc_TypeError, "bad return type from comparator");
+            return NULL;
+        }
+        
+        long long comp_result = PyLong_AsLongLong(comp);
+        Py_DECREF(comp);
+        
+        PyObject* tmp;
+        if (comp_result == 1) { // curr key is larger; insert left
+            tmp = self->left;
+            self->left = BSTInsert((BST*)self->left, args, kwargs);
+            Py_DECREF(tmp);
+        } else if(comp_result == 0) {
+            self->data = data;
+        } else {
+            tmp = self->right;
+            self->right = BSTInsert((BST*)self->right, args, kwargs);
+            Py_DECREF(tmp);
+        }
+        
+        Py_INCREF(self);
+        return (PyObject*)self;
+    }
+}
+
+// The below insert() works completely without keywords
+
+// static PyObject* BSTInsert(BST* self, PyObject* args) {
+//     PyObject *key, *elem, *comparator = NULL;
+//     if (!PyArg_ParseTuple(args, "OOO", &key, &elem, &comparator)) {
+//         return NULL;
+//     }
+    
+//     if (!PyCallable_Check(comparator)) {
+//         PyErr_SetString(PyExc_ValueError, "comparator should be callable");
+//         return NULL;
+//     }
+//     if (self == Py_None) {
+//         BST * b = BSTAlloc(&BSTType, NULL, NULL);
+//         PyObject* argument = Py_BuildValue("(OO)", key, elem);
+//         BSTInit(b, argument, NULL);
+//         Py_DECREF(argument);
+//         return b;
+//     }
+//     PyObject* arguments = Py_BuildValue("OO", self->key, elem);
+//     PyObject* comp = PyObject_CallObject(comparator, arguments);
+//     Py_DECREF(arguments);
+//     if (!PyLong_Check(comp)) {
+//         PyErr_SetString(PyExc_TypeError, "bad return type from comparator");
+//         return NULL;
+//     }
+//     long long comp_result = PyLong_AsLongLong(comp);
+//     Py_DECREF(comp);
+//     PyObject* tmp;
+//     if (comp_result == 1) { // curr elem is larger; insert left
+//         tmp = self->left;
+//         self->left = BSTInsert(self->left, args);
+//         Py_DECREF(tmp);
+//     } else {
+//         tmp = self->right;
+//         self->right = BSTInsert(self->right, args);
+//         Py_DECREF(tmp);
+//     }
+//     Py_INCREF(self);
+//     return self;
+// }
+
+
+static PyModuleDef BSTmodule = {
+    PyModuleDef_HEAD_INIT,
+    "BST",
+    "c extension of BST",
+    -1,
+    NULL, NULL, NULL, NULL, NULL
+};
+
+
+PyMODINIT_FUNC PyInit_BST(void) {
+    if (PyType_Ready(&BSTType) < 0) {
+        return NULL;
+    }
+    PyObject* m = PyModule_Create(&BSTmodule);
+    if (!m) {
+        return NULL;
+    }
+    Py_INCREF(&BSTType);
+    PyModule_AddObject(m, "BST", (PyObject*)&BSTType);
+    return m;
+}
+
+
+
+
+
+
+

--- a/BST_module.hpp
+++ b/BST_module.hpp
@@ -1,0 +1,58 @@
+//
+//  BST_module.h
+//  BST
+//
+//  Created by dwd on 12/27/17.
+//  Copyright © 2017 holdendou. All rights reserved.
+//
+
+#ifndef BST_module_h
+#define BST_module_h
+
+#include <stdio.h>
+#include <Python.h>
+#include <structmember.h>
+
+typedef struct {
+    PyObject_HEAD
+    PyObject* key;
+    PyObject* data;
+    PyObject* left;
+    PyObject* right;
+} BST;
+
+static PyMemberDef BSTMembers[] = {
+    {"key", T_OBJECT_EX, offsetof(BST, key), 0, "key of BST node"},
+    {"data", T_OBJECT_EX, offsetof(BST, data), 0, "data of a BST node"},
+    {"left", T_OBJECT_EX, offsetof(BST, left), 0, "left child"},
+    {"right", T_OBJECT_EX, offsetof(BST, right), 0, "right child"},
+    {NULL}
+};
+
+static PyObject* BSTListify(BST* self);
+static PyObject* BSTInsert(BST* self, PyObject* args, PyObject* kwargs);
+static PyObject* BSTSearch(BST* self, PyObject* args);
+
+static PyMethodDef BSTMethods[] = {
+    {
+        "listify",
+        (PyCFunction)BSTListify,
+        METH_NOARGS,
+        "inorder traversal of the binary tree"
+    },
+    {
+        "insert",
+        (PyCFunction)BSTInsert,
+        METH_VARARGS | METH_KEYWORDS,
+        "insert an element"
+    },
+    {
+        "search",
+        (PyCFunction)BSTSearch,
+        METH_VARARGS,
+        "search for an element in the binary tree"
+    },
+    {NULL}
+};
+
+#endif /* BST_module_h */

--- a/setup2.py
+++ b/setup2.py
@@ -1,0 +1,6 @@
+from distutils.core import setup, Extension
+setup(name="BST", version="1.0",
+      ext_modules=[
+          Extension("BST", sources=["BST_module.cpp"])
+      ]
+)

--- a/test.py
+++ b/test.py
@@ -1,0 +1,35 @@
+from BST import BST
+
+def int_comp(curr, new):
+    if curr > new:
+        return 1
+    elif curr < new:
+        return -1
+    else:
+        return 0
+
+b = BST(1, 666);
+print(b)
+
+print(b.data)
+print(b.key)
+
+# Keywords can now be used. But all must be keywords or none
+b.insert(data=777, key=2)
+# b = b.insert(2, 777, int_comp)
+b.insert(3, 888)
+b.insert(4, 555, int_comp)
+print(b.listify())
+b.insert(3, 333)
+print(b.listify())
+print(b.search(3))
+print(b.search(8))
+# print(b.left)
+# print(b.right)
+
+# print(str(b))
+
+# b.left = BST(777)
+# b.right = BST(888)
+
+# print(b.listify())


### PR DESCRIPTION
Towards #554 

### Progress:

BST insert() and search() are working properly, with data, key and comparator as keyword arguments.


I have added `BST_module.cpp` and `BST_module.hpp` with a new setup file : `setup2.py`. Also a test file `test.py`

Run using: `python setup2.py install --user`

### To Do: 
Put these files in the proper folder and write appropriate commands in `setup.py` and `develop.py`. Also add backend.CPP check conditions.

### What's working: 

Here is the test file.

```
from BST import BST

def int_comp(curr, new):
    if curr > new:
        return 1
    elif curr < new:
        return -1
    else:
        return 0

b = BST(1, 666);
print(b)

print(b.data)
print(b.key)

# Keywords can now be used. But all must be keywords or none

b.insert(data=777, key=2)
b.insert(3, 888)
b.insert(4, 555, int_comp)
print(b.listify())
b.insert(3, 333)
print(b.listify())
print(b.search(3))
print(b.search(8))
```

### Output:
```
kishan@kishan-IdeaPad-3-15IIL05:~/Desktop/pydatastructs$ python test.py
<BST.BST object at 0x754afe4affc0>
666
1
[666, 777, 888, 555]
[666, 777, 333, 555]
True
False
```