### PR TITLE
feat: `add pyds.maximum_subarray_sum_1`

### DIFF
--- a/docs/source/pydatastructs/linear_data_structures/algorithms.rst
+++ b/docs/source/pydatastructs/linear_data_structures/algorithms.rst
@@ -46,3 +46,5 @@ Algorithms
 .. autofunction:: pydatastructs.jump_search
 
 .. autofunction:: pydatastructs.intro_sort
+
+.. autofunction:: pydatastructs.maximum_subarray_sum_1

--- a/pydatastructs/linear_data_structures/__init__.py
+++ b/pydatastructs/linear_data_structures/__init__.py
@@ -47,6 +47,7 @@ from .algorithms import (
     jump_search,
     selection_sort,
     insertion_sort,
-    intro_sort
+    intro_sort,
+    maximum_subarray_sum_1
 )
 __all__.extend(algorithms.__all__)

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -30,7 +30,8 @@ __all__ = [
     'jump_search',
     'selection_sort',
     'insertion_sort',
-    'intro_sort'
+    'intro_sort',
+    'maximum_subarray_sum_1'
 ]
 
 def _merge(array, sl, el, sr, er, end, comp):
@@ -1850,3 +1851,62 @@ def intro_sort(array, **kwargs) -> Array:
         intro_sort(array, start=p+1, end=upper,  maxdepth=maxdepth-1, ins_threshold=ins_threshold)
 
         return array
+
+def maximum_subarray_sum_1(array, **kwargs):
+    """
+    Finds the maximum subarray sum of the given array using a brute force approach.
+    Parameters
+    ==========
+    array: OneDimensionalArray
+        The array for which the maximum subarray sum
+        has to be found.
+    start: int
+        The starting index of the portion
+        which is to be considered.
+        Optional, by default 0
+    end: int
+        The ending index of the portion which
+        is to be considered.
+        Optional, by default the index
+        of the last position filled.
+    comp: lambda/function
+        The comparator which is to be used
+        for performing comparisons.
+        Optional, by default, less than or
+        equal to is used for comparing two
+        values.
+    backend: pydatastructs.Backend
+        The backend to be used.
+        Optional, by default, the best available
+        backend is used.
+    Returns
+    =======
+    output: int
+        The maximum subarray sum.
+    Examples
+    ========
+    >>> from pydatastructs import OneDimensionalArray as ODA, maximum_subarray_sum_1
+    >>> arr = ODA(int, [-2, 1, -3, 4, -1, 2, 1, -5, 4])
+    >>> maximum_subarray_sum_1(arr)
+    6
+    >>> arr = ODA(int, [1, 2, 3, 4, 5])
+    >>> maximum_subarray_sum_1(arr)
+    15
+    References
+    ==========
+    .. [1] https://en.wikipedia.org/wiki/Maximum_subarray_problem
+    """
+    raise_if_backend_is_not_python(
+        maximum_subarray_sum_1, kwargs.get('backend', Backend.PYTHON))
+    start = kwargs.get('start', 0)
+    end = kwargs.get('end', len(array) - 1)
+    comp = kwargs.get('comp', lambda u, v: u <= v)
+
+    max_sum = float('-inf')
+    for i in range(start, end + 1):
+        curr_sum = 0
+        for j in range(i, end + 1):
+            curr_sum += array[j]
+            max_sum = max(max_sum, curr_sum)
+
+    return max_sum

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -5,7 +5,7 @@ from pydatastructs import (
     cocktail_shaker_sort, quick_sort, longest_common_subsequence, is_ordered,
     upper_bound, lower_bound, longest_increasing_subsequence, next_permutation,
     prev_permutation, bubble_sort, linear_search, binary_search, jump_search,
-    selection_sort, insertion_sort, intro_sort, Backend)
+    selection_sort, insertion_sort, intro_sort, maximum_subarray_sum_1, Backend)
 
 from pydatastructs.utils.raises_util import raises
 import random

--- a/pydatastructs/utils/tests/test_code_quality.py
+++ b/pydatastructs/utils/tests/test_code_quality.py
@@ -174,7 +174,7 @@ def _apis():
     pyds.Trie, pyds.TrieNode, pyds.SkipList, pyds.RangeQueryStatic, pyds.RangeQueryDynamic, pyds.SparseTable,
     pyds.miscellaneous_data_structures.segment_tree.OneDimensionalArraySegmentTree,
     pyds.bubble_sort, pyds.linear_search, pyds.binary_search, pyds.jump_search,
-    pyds.selection_sort, pyds.insertion_sort, pyds.quick_sort, pyds.intro_sort]
+    pyds.selection_sort, pyds.insertion_sort, pyds.quick_sort, pyds.intro_sort, pyds.maximum_subarray_sum_1]
 
 def test_public_api():
     pyds = pydatastructs


### PR DESCRIPTION
This update introduces a brute force approach to finding the maximum subarray sum by iterating over all possible subarrays. It serves as an alternative to Kadane’s Algorithm, with a time complexity of O(n²).

#### Brief description of what is fixed or changed

This update adds a brute force implementation for finding the maximum subarray sum by iterating over all possible subarrays. Unlike Kadane’s algorithm (O(n)), this method follows an O(n²) complexity, making it useful for understanding naive approaches and verifying correctness in small test cases.
