### PR TITLE
FIX: Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           update-conda: true
           python-version: ${{ matrix.python-version }}
           conda-channels: anaconda, conda-forge
-      - run: conda --version
+      # - run: conda --version  # This fails due to unknown reasons
       - run: which python
 
       - name: Upgrade pip version


### PR DESCRIPTION
<!-- Your title above should be a short description of what
was changed. Do not include the issue number in the title. -->
Recently, the windows CI has been failing due to some reason that is beyond my conscious. Hence, let's remove the command that caused the fail:

`run: conda --version`

Removal of this shouldn't matter as such.

