### PR TITLE
feat: replace Bellman Ford Algorithm with queue version

### DIFF
--- a/pydatastructs/graphs/algorithms.py
+++ b/pydatastructs/graphs/algorithms.py
@@ -697,7 +697,7 @@ def shortest_paths(graph: Graph, algorithm: str,
         The algorithm to be used. Currently, the following algorithms
         are implemented,
 
-        'bellman_ford' -> Bellman-Ford algorithm as given in [1], with a queue to improve performance on sparse graphs.
+        'bellman_ford' -> Bellman-Ford algorithm as given in [1]
 
         'dijkstra' -> Dijkstra algorithm as given in [2].
     source: str

--- a/pydatastructs/graphs/algorithms.py
+++ b/pydatastructs/graphs/algorithms.py
@@ -700,6 +700,8 @@ def shortest_paths(graph: Graph, algorithm: str,
         'bellman_ford' -> Bellman-Ford algorithm as given in [1].
 
         'dijkstra' -> Dijkstra algorithm as given in [2].
+
+        'queue_improved_bellman_ford' -> Queue Improved Bellman-Ford algorithm as given in [3].
     source: str
         The name of the source the node.
     target: str
@@ -742,6 +744,7 @@ def shortest_paths(graph: Graph, algorithm: str,
 
     .. [1] https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm
     .. [2] https://en.wikipedia.org/wiki/Dijkstra%27s_algorithm
+    .. [3] https://en.wikipedia.org/wiki/Bellman%E2%80%93Ford_algorithm#Improvements
     """
     raise_if_backend_is_not_python(
         shortest_paths, kwargs.get('backend', Backend.PYTHON))
@@ -810,6 +813,37 @@ def _dijkstra_adjacency_list(graph: Graph, start: str, target: str):
     return dist, pred
 
 _dijkstra_adjacency_matrix = _dijkstra_adjacency_list
+
+def _queue_improved_bellman_ford_adjacency_list(graph: Graph, source: str, target: str) -> tuple:
+    distances, predecessor, visited = {}, {}, {}
+
+    for v in graph.vertices:
+        distances[v] = float('inf')
+        predecessor[v] = None
+        visited[v] = False
+    distances[source] = 0
+
+    que = Queue([source])
+
+    while que:
+        u = que.popleft()
+        visited[u] = False
+        neighbors = graph.neighbors(u)
+        for neighbor in neighbors:
+            v = neighbor.name
+            edge_str = u + '_' + v
+            if distances[u] != float('inf') and distances[u] + graph.edge_weights[edge_str].value < distances[v]:
+                distances[v] = distances[u] + graph.edge_weights[edge_str].value
+                predecessor[v] = u
+                if not visited[v]:
+                    que.append(v)
+                    visited[v] = True
+
+    if target != "":
+        return (distances[target], predecessor)
+    return (distances, predecessor)
+
+_queue_improved_bellman_ford_adjacency_matrix = _queue_improved_bellman_ford_adjacency_list
 
 def all_pair_shortest_paths(graph: Graph, algorithm: str,
                             **kwargs) -> tuple:

--- a/pydatastructs/graphs/tests/test_algorithms.py
+++ b/pydatastructs/graphs/tests/test_algorithms.py
@@ -321,10 +321,6 @@ def test_shortest_paths():
     _test_shortest_paths_negative_edges("Matrix", 'bellman_ford')
     _test_shortest_paths_positive_edges("List", 'dijkstra')
     _test_shortest_paths_positive_edges("Matrix", 'dijkstra')
-    _test_shortest_paths_positive_edges("List", 'queue_improved_bellman_ford')
-    _test_shortest_paths_positive_edges("Matrix", 'queue_improved_bellman_ford')
-    _test_shortest_paths_negative_edges("List", 'queue_improved_bellman_ford')
-    _test_shortest_paths_negative_edges("Matrix", 'queue_improved_bellman_ford')
 
 def test_all_pair_shortest_paths():
 

--- a/pydatastructs/graphs/tests/test_algorithms.py
+++ b/pydatastructs/graphs/tests/test_algorithms.py
@@ -321,6 +321,10 @@ def test_shortest_paths():
     _test_shortest_paths_negative_edges("Matrix", 'bellman_ford')
     _test_shortest_paths_positive_edges("List", 'dijkstra')
     _test_shortest_paths_positive_edges("Matrix", 'dijkstra')
+    _test_shortest_paths_positive_edges("List", 'queue_improved_bellman_ford')
+    _test_shortest_paths_positive_edges("Matrix", 'queue_improved_bellman_ford')
+    _test_shortest_paths_negative_edges("List", 'queue_improved_bellman_ford')
+    _test_shortest_paths_negative_edges("Matrix", 'queue_improved_bellman_ford')
 
 def test_all_pair_shortest_paths():
 


### PR DESCRIPTION
Implementing queue improved bellman ford algorithm.

Also known as the “shortest path faster algorithm”.

For the Bellman-Ford algorithm, each iteration requires relaxing all edges. For a vertex v that has a distance value that has not changed since the last time the edges out of v were relaxed, then there is no need to relax the edges out of v a second time.

Changes in PR:
1. Implementation of queue improved bellman ford algorithm.
2. Add tests for queue improved bellman ford algorithm.
3. Add choices for shorted path algorithm and related comment.

Related to https://github.com/codezonediitj/pydatastructs/issues/628
