### PR TITLE
feat: Implement add_vertex and remove_vertex for AdjacencyMatrix

### DIFF
--- a/pydatastructs/graphs/adjacency_matrix.py
+++ b/pydatastructs/graphs/adjacency_matrix.py
@@ -57,12 +57,30 @@ class AdjacencyMatrix(Graph):
         return neighbors
 
     def add_vertex(self, node):
-        raise NotImplementedError("Currently we allow "
-                "adjacency matrix for static graphs only")
+        node_name = str(node.name)
+        if node_name in self.vertices:
+            raise ValueError(f"Vertex {node_name} already exists in the graph.")
+        self.vertices.append(node_name)
+        self.__setattr__(node_name, node)
+        self.matrix[node_name] = {}
+        for vertex in self.vertices:
+            self.matrix[vertex][node_name] = False
+            self.matrix[node_name][vertex] = False
 
     def remove_vertex(self, node):
-        raise NotImplementedError("Currently we allow "
-                "adjacency matrix for static graphs only.")
+        node_name = str(node)
+        if node_name not in self.vertices:
+            raise ValueError(f"Vertex {node_name} does not exist in the graph.")
+        self.vertices.remove(node_name)
+        del self.matrix[node_name]
+        for vertex in self.vertices:
+            del self.matrix[vertex][node_name]
+        edges_to_remove = []
+        for edge in self.edge_weights.keys():
+            if node_name in edge:
+                edges_to_remove.append(edge)
+        for edge in edges_to_remove:
+            del self.edge_weights[edge]
 
     def add_edge(self, source, target, cost=None):
         source, target = str(source), str(target)

--- a/pydatastructs/graphs/tests/test_adjacency_matrix.py
+++ b/pydatastructs/graphs/tests/test_adjacency_matrix.py
@@ -30,3 +30,12 @@ def test_AdjacencyMatrix():
     assert raises(ValueError, lambda: g.add_edge('v', 'x'))
     assert raises(ValueError, lambda: g.add_edge(2, 3))
     assert raises(ValueError, lambda: g.add_edge(3, 2))
+    v_3 = AdjacencyMatrixGraphNode(3, 3)
+    g.add_vertex(v_3)
+    assert '3' in g.vertices
+    assert g.is_adjacent(3, 0) is False
+    g.add_edge(3, 0, 0)
+    assert g.is_adjacent(3, 0) is True
+    g.remove_vertex(3)
+    assert '3' not in g.vertices
+    assert raises(ValueError, lambda: g.add_edge(3, 0))


### PR DESCRIPTION
## Description

This PR implements the `add_vertex` and `remove_vertex` methods for the `AdjacencyMatrix` class, enabling support for dynamic graphs. Previously, the adjacency matrix implementation only supported static graphs, as indicated by the `NotImplementedError` in these methods. This enhancement allows users to add or remove vertices after the graph is initialized, making the adjacency matrix representation more versatile.

## Changes

- **`add_vertex` Method**:
  - Adds a new vertex to the `vertices` list.
  - Initializes a new row and column in the adjacency matrix for the new vertex.
  - Sets all entries in the new row and column to `False` (indicating no edges initially).

- **`remove_vertex` Method**:
  - Removes the vertex from the `vertices` list.
  - Removes the corresponding row and column from the adjacency matrix.
  - Removes all edges connected to the vertex from the `edge_weights` dictionary.

- **Tests**:
  - Added test cases to verify the functionality of `add_vertex` and `remove_vertex`.
  - Ensured that the adjacency matrix and edge weights are updated correctly.

## Fixes : #634 