### PR TITLE
Add `is_palindrome` method to LinkedList class

### DIFF
--- a/pydatastructs/linear_data_structures/linked_lists.py
+++ b/pydatastructs/linear_data_structures/linked_lists.py
@@ -206,6 +206,39 @@ class LinkedList(object):
         """
         return self.extract(-1)
 
+    def is_palindrome(self) -> bool:
+        """
+        Checks if the linked list is a palindrome.
+
+        Returns
+        =======
+
+        bool
+            True if the linked list is a palindrome, otherwise False.
+
+        Examples
+        ========
+
+        >>> from pydatastructs import SinglyLinkedList
+        >>> sll = SinglyLinkedList()
+        >>> sll.append(1)
+        >>> sll.append(2)
+        >>> sll.append(1)
+        >>> sll.is_palindrome()
+        True
+        >>> sll.append(3)
+        >>> sll.is_palindrome()
+        False
+        """
+        elements = []
+        current_node = self.head
+        while current_node is not None:
+            elements.append(current_node.key)
+            current_node = current_node.next
+            if current_node == self.head:
+                break
+        return elements == elements[::-1]
+
 class DoublyLinkedList(LinkedList):
     """
     Represents Doubly Linked List

--- a/pydatastructs/linear_data_structures/tests/test_linked_lists.py
+++ b/pydatastructs/linear_data_structures/tests/test_linked_lists.py
@@ -43,6 +43,20 @@ def test_DoublyLinkedList():
     assert str(dll_copy) == "[]"
     assert raises(ValueError, lambda: dll_copy.extract(1))
 
+    dll_palindrome = DoublyLinkedList()
+    dll_palindrome.append(1)
+    dll_palindrome.append(2)
+    dll_palindrome.append(3)
+    dll_palindrome.append(2)
+    dll_palindrome.append(1)
+    assert dll_palindrome.is_palindrome() is True
+
+    dll_not_palindrome = DoublyLinkedList()
+    dll_not_palindrome.append(1)
+    dll_not_palindrome.append(2)
+    dll_not_palindrome.append(3)
+    assert dll_not_palindrome.is_palindrome() is False
+
 def test_SinglyLinkedList():
     random.seed(1000)
     sll = SinglyLinkedList()
@@ -78,6 +92,20 @@ def test_SinglyLinkedList():
         sll_copy.extract(index)
     assert str(sll_copy) == "[]"
     assert raises(ValueError, lambda: sll_copy.extract(1))
+
+    sll_palindrome = SinglyLinkedList()
+    sll_palindrome.append(1)
+    sll_palindrome.append(2)
+    sll_palindrome.append(3)
+    sll_palindrome.append(2)
+    sll_palindrome.append(1)
+    assert sll_palindrome.is_palindrome() is True
+
+    sll_not_palindrome = SinglyLinkedList()
+    sll_not_palindrome.append(1)
+    sll_not_palindrome.append(2)
+    sll_not_palindrome.append(3)
+    assert sll_not_palindrome.is_palindrome() is False
 
 def test_SinglyCircularLinkedList():
     random.seed(1000)
@@ -115,6 +143,20 @@ def test_SinglyCircularLinkedList():
         scll_copy.extract(index)
     assert str(scll_copy) == "[]"
     assert raises(ValueError, lambda: scll_copy.extract(1))
+
+    scll_palindrome = SinglyCircularLinkedList()
+    scll_palindrome.append(1)
+    scll_palindrome.append(2)
+    scll_palindrome.append(3)
+    scll_palindrome.append(2)
+    scll_palindrome.append(1)
+    assert scll_palindrome.is_palindrome() is True
+
+    scll_not_palindrome = SinglyCircularLinkedList()
+    scll_not_palindrome.append(1)
+    scll_not_palindrome.append(2)
+    scll_not_palindrome.append(3)
+    assert scll_not_palindrome.is_palindrome() is False
 
 def test_DoublyCircularLinkedList():
     random.seed(1000)
@@ -154,6 +196,20 @@ def test_DoublyCircularLinkedList():
         dcll_copy.extract(index)
     assert str(dcll_copy) == "[]"
     assert raises(ValueError, lambda: dcll_copy.extract(1))
+
+    dcll_palindrome = DoublyCircularLinkedList()
+    dcll_palindrome.append(1)
+    dcll_palindrome.append(2)
+    dcll_palindrome.append(3)
+    dcll_palindrome.append(2)
+    dcll_palindrome.append(1)
+    assert dcll_palindrome.is_palindrome() is True
+
+    dcll_not_palindrome = DoublyCircularLinkedList()
+    dcll_not_palindrome.append(1)
+    dcll_not_palindrome.append(2)
+    dcll_not_palindrome.append(3)
+    assert dcll_not_palindrome.is_palindrome() is False
 
 def test_SkipList():
     random.seed(0)


### PR DESCRIPTION
## What's this PR about?
This PR adds a new method `is_palindrome` to the `LinkedList` class to check if a linked list is a palindrome. The method works for all types of linked lists: `SinglyLinkedList`, `DoublyLinkedList`, `SinglyCircularLinkedList`, and `DoublyCircularLinkedList`.

## What changes were made?
1. **New Method:**
   - Added `is_palindrome` to the `LinkedList` class.
   - The method traverses the linked list, stores elements in a temporary array, and checks if the array is equal to its reverse.

2. **Tests:**
   - Added comprehensive test cases for `is_palindrome` in the test file.
   - Verified functionality for all linked list types.

## Fixes: #656 