### PR TITLE
Add Reverse Method to Linear Data Structures

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Pratik Goyal <pratikgoyal2712@gmail.com>
 Jay Thorat <j.thorat10@gmail.com>
 Rajveer Singh Bharadwaj <rsb3256@gmail.com>
 Kishan Ved <kishanved123456@gmail.com>
+Arvinder Singh Dhoul <asdhoul004@gmail.com>

--- a/docs/source/pydatastructs/linear_data_structures/algorithms.rst
+++ b/docs/source/pydatastructs/linear_data_structures/algorithms.rst
@@ -46,3 +46,7 @@ Algorithms
 .. autofunction:: pydatastructs.jump_search
 
 .. autofunction:: pydatastructs.intro_sort
+
+.. autofunction:: pydatastructs.shell_sort
+
+.. autofunction:: pydatastructs.radix_sort

--- a/docs/source/pydatastructs/linear_data_structures/algorithms.rst
+++ b/docs/source/pydatastructs/linear_data_structures/algorithms.rst
@@ -50,3 +50,5 @@ Algorithms
 .. autofunction:: pydatastructs.shell_sort
 
 .. autofunction:: pydatastructs.radix_sort
+
+.. autofunction:: pydatastructs.reverse_array

--- a/pydatastructs/linear_data_structures/__init__.py
+++ b/pydatastructs/linear_data_structures/__init__.py
@@ -49,6 +49,7 @@ from .algorithms import (
     insertion_sort,
     intro_sort,
     shell_sort,
-    radix_sort
+    radix_sort,
+    reverse_array
 )
 __all__.extend(algorithms.__all__)

--- a/pydatastructs/linear_data_structures/__init__.py
+++ b/pydatastructs/linear_data_structures/__init__.py
@@ -47,6 +47,8 @@ from .algorithms import (
     jump_search,
     selection_sort,
     insertion_sort,
-    intro_sort
+    intro_sort,
+    shell_sort,
+    radix_sort
 )
 __all__.extend(algorithms.__all__)

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -32,7 +32,8 @@ __all__ = [
     'insertion_sort',
     'intro_sort',
     'shell_sort',
-    'radix_sort'
+    'radix_sort',
+    'reverse_array'
 ]
 
 def _merge(array, sl, el, sr, er, end, comp):
@@ -2008,6 +2009,53 @@ def radix_sort(array, *args, **kwargs):
             array[start + i] = output[i]
 
         exp *= 10
+
+    if _check_type(array, (DynamicArray, _arrays.DynamicOneDimensionalArray)):
+        array._modify(True)
+
+    return array
+
+def reverse_array(array, *args, **kwargs):
+    """
+    Reverses the specified portion of the array in-place.
+
+    Parameters
+    ==========
+
+    array: Array
+        The array to be reversed (DynamicOneDimensionalArray or OneDimensionalArray).
+    start: int
+        The starting index of the portion to reverse.
+        Optional, by default 0
+    end: int
+        The ending index of the portion to reverse.
+        Optional, by default the index of the last position filled.
+    backend: pydatastructs.Backend
+        The backend to be used (PYTHON or CPP).
+        Optional, by default, the best available backend is used.
+
+    Returns
+    =======
+
+    output: Array
+        The array with the specified portion reversed.
+    """
+    start = int(kwargs.get('start', 0))
+    end = int(kwargs.get('end', len(array) - 1))
+
+    if start >= end:
+        return array
+    n = end - start + 1
+
+    elements = [(array[i], i) for i in range(start, end + 1) if array[i] is not None]
+    elem_values = [e[0] for e in elements]
+    elem_values.reverse()
+
+    k = 0
+    for i in range(start, end + 1):
+        if array[i] is not None:
+            array[i] = elem_values[k]
+            k += 1
 
     if _check_type(array, (DynamicArray, _arrays.DynamicOneDimensionalArray)):
         array._modify(True)

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -1850,3 +1850,78 @@ def intro_sort(array, **kwargs) -> Array:
         intro_sort(array, start=p+1, end=upper,  maxdepth=maxdepth-1, ins_threshold=ins_threshold)
 
         return array
+
+def shell_sort(array, **kwargs):
+    """
+    Implements shell sort algorithm.
+
+    Parameters
+    ==========
+
+    array: Array
+        The array which is to be sorted.
+    start: int
+        The starting index of the portion
+        which is to be sorted.
+        Optional, by default 0
+    end: int
+        The ending index of the portion which
+        is to be sorted.
+        Optional, by default the index
+        of the last position filled.
+    comp: lambda/function
+        The comparator which is to be used
+        for sorting. If the function returns
+        False then only swapping is performed.
+        Optional, by default, less than or
+        equal to is used for comparing two
+        values.
+    backend: pydatastructs.Backend
+        The backend to be used.
+        Optional, by default, the best available
+        backend is used.
+
+    Returns
+    =======
+
+    output: Array
+        The sorted array.
+
+    Examples
+    ========
+
+    >>> from pydatastructs.linear_data_structures.algorithms import OneDimensionalArray, shell_sort
+    >>> arr = OneDimensionalArray(int, [3, 2, 1])
+    >>> out = shell_sort(arr)
+    >>> str(out)
+    '[1, 2, 3]'
+    >>> out = shell_sort(arr, comp=lambda u, v: u > v)
+    >>> str(out)
+    '[3, 2, 1]'
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Shellsort
+    """
+    backend = kwargs.pop("backend", Backend.PYTHON)
+    if backend == Backend.CPP:
+        return _algorithms.shell_sort(array, **kwargs)
+    start = kwargs.get('start', 0)
+    end = kwargs.get('end', len(array) - 1)
+    comp = kwargs.get('comp', lambda u, v: u <= v)
+    n = end - start + 1
+    gap = n // 2
+    while gap > 0:
+        for i in range(start + gap, end + 1):
+            temp = array[i]
+            j = i
+            while j >= start + gap and not _comp(array[j - gap], temp, comp):
+                array[j] = array[j - gap]
+                j -= gap
+            array[j] = temp
+        gap //= 2
+    if _check_type(array, (DynamicArray, _arrays.DynamicOneDimensionalArray)):
+        array._modify(True)
+
+    return array

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -1853,7 +1853,7 @@ def intro_sort(array, **kwargs) -> Array:
 
         return array
 
-def shell_sort(array, **kwargs):
+def shell_sort(array, *args, **kwargs):
     """
     Implements shell sort algorithm.
 
@@ -1906,9 +1906,10 @@ def shell_sort(array, **kwargs):
 
     .. [1] https://en.wikipedia.org/wiki/Shellsort
     """
-    start = kwargs.get('start', 0)
-    end = kwargs.get('end', len(array) - 1)
+    start = int(kwargs.get('start', 0))
+    end = int(kwargs.get('end', len(array) - 1))
     comp = kwargs.get('comp', lambda u, v: u <= v)
+
     n = end - start + 1
     gap = n // 2
     while gap > 0:
@@ -1920,12 +1921,13 @@ def shell_sort(array, **kwargs):
                 j -= gap
             array[j] = temp
         gap //= 2
+
     if _check_type(array, (DynamicArray, _arrays.DynamicOneDimensionalArray)):
         array._modify(True)
 
     return array
 
-def radix_sort(array, **kwargs):
+def radix_sort(array, *args, **kwargs):
     """
     Implements radix sort algorithm for non-negative integers.
 
@@ -1977,36 +1979,31 @@ def radix_sort(array, **kwargs):
     """
     start = int(kwargs.get('start', 0))
     end = int(kwargs.get('end', len(array) - 1))
-
-    if start >= end:
-        return array
+    comp = kwargs.get('comp', lambda u, v: u <= v)
 
     n = end - start + 1
-    if n <= 0:
-        return array
-
     max_val = array[start]
     for i in range(start + 1, end + 1):
-        if array[i] > max_val:
+        if array[i] is not None and array[i] > max_val:
             max_val = array[i]
-    if max_val < 0:
-        raise ValueError("Radix sort requires non-negative integers")
-
     exp = 1
     while max_val // exp > 0:
         count = [0] * 10
-        output = [0] * n
+        output = [None] * n
+
         for i in range(start, end + 1):
-            digit = (array[i] // exp) % 10
-            count[digit] += 1
+            if array[i] is not None:
+                digit = (array[i] // exp) % 10
+                count[digit] += 1
 
         for i in range(1, 10):
             count[i] += count[i - 1]
 
         for i in range(end, start - 1, -1):
-            digit = (array[i] // exp) % 10
-            count[digit] -= 1
-            output[count[digit]] = array[i]
+            if array[i] is not None:
+                digit = (array[i] // exp) % 10
+                count[digit] -= 1
+                output[count[digit]] = array[i]
 
         for i in range(n):
             array[start + i] = output[i]

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -30,7 +30,9 @@ __all__ = [
     'jump_search',
     'selection_sort',
     'insertion_sort',
-    'intro_sort'
+    'intro_sort',
+    'shell_sort',
+    'radix_sort'
 ]
 
 def _merge(array, sl, el, sr, er, end, comp):
@@ -1904,9 +1906,6 @@ def shell_sort(array, **kwargs):
 
     .. [1] https://en.wikipedia.org/wiki/Shellsort
     """
-    backend = kwargs.pop("backend", Backend.PYTHON)
-    if backend == Backend.CPP:
-        return _algorithms.shell_sort(array, **kwargs)
     start = kwargs.get('start', 0)
     end = kwargs.get('end', len(array) - 1)
     comp = kwargs.get('comp', lambda u, v: u <= v)
@@ -1976,9 +1975,6 @@ def radix_sort(array, **kwargs):
 
     .. [1] https://en.wikipedia.org/wiki/Radix_sort
     """
-    backend = kwargs.pop("backend", Backend.PYTHON)
-    if backend == Backend.CPP:
-        return _algorithms.radix_sort(array, **kwargs)
     start = int(kwargs.get('start', 0))
     end = int(kwargs.get('end', len(array) - 1))
 

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -1979,7 +1979,6 @@ def radix_sort(array, *args, **kwargs):
     """
     start = int(kwargs.get('start', 0))
     end = int(kwargs.get('end', len(array) - 1))
-    comp = kwargs.get('comp', lambda u, v: u <= v)
 
     n = end - start + 1
     max_val = array[start]

--- a/pydatastructs/linear_data_structures/algorithms.py
+++ b/pydatastructs/linear_data_structures/algorithms.py
@@ -1925,3 +1925,99 @@ def shell_sort(array, **kwargs):
         array._modify(True)
 
     return array
+
+def radix_sort(array, **kwargs):
+    """
+    Implements radix sort algorithm for non-negative integers.
+
+    Parameters
+    ==========
+
+    array: Array
+        The array which is to be sorted. Must contain non-negative integers.
+    start: int
+        The starting index of the portion
+        which is to be sorted.
+        Optional, by default 0
+    end: int
+        The ending index of the portion which
+        is to be sorted.
+        Optional, by default the index
+        of the last position filled.
+    comp: lambda/function
+        The comparator which is to be used
+        for sorting. If the function returns
+        False then only swapping is performed.
+        Optional, by default, less than or
+        equal to is used for comparing two
+        values.
+    backend: pydatastructs.Backend
+        The backend to be used.
+        Optional, by default, the best available
+        backend is used.
+
+    Returns
+    =======
+
+    output: Array
+        The sorted array.
+
+    Examples
+    ========
+
+    >>> from pydatastructs.linear_data_structures.algorithms import OneDimensionalArray, radix_sort
+    >>> arr = OneDimensionalArray(int, [170, 45, 75, 90, 802, 24, 2, 66])
+    >>> out = radix_sort(arr)
+    >>> str(out)
+    '[2, 24, 45, 66, 75, 90, 170, 802]'
+
+    References
+    ==========
+
+    .. [1] https://en.wikipedia.org/wiki/Radix_sort
+    """
+    backend = kwargs.pop("backend", Backend.PYTHON)
+    if backend == Backend.CPP:
+        return _algorithms.radix_sort(array, **kwargs)
+    start = int(kwargs.get('start', 0))
+    end = int(kwargs.get('end', len(array) - 1))
+
+    if start >= end:
+        return array
+
+    n = end - start + 1
+    if n <= 0:
+        return array
+
+    max_val = array[start]
+    for i in range(start + 1, end + 1):
+        if array[i] > max_val:
+            max_val = array[i]
+    if max_val < 0:
+        raise ValueError("Radix sort requires non-negative integers")
+
+    exp = 1
+    while max_val // exp > 0:
+        count = [0] * 10
+        output = [0] * n
+        for i in range(start, end + 1):
+            digit = (array[i] // exp) % 10
+            count[digit] += 1
+
+        for i in range(1, 10):
+            count[i] += count[i - 1]
+
+        for i in range(end, start - 1, -1):
+            digit = (array[i] // exp) % 10
+            count[digit] -= 1
+            output[count[digit]] = array[i]
+
+        for i in range(n):
+            array[start + i] = output[i]
+
+        exp *= 10
+
+    if _check_type(array, (DynamicArray, _arrays.DynamicOneDimensionalArray)):
+        array._modify(True)
+
+    return array

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -7,9 +7,9 @@ from pydatastructs import (
     prev_permutation, bubble_sort, linear_search, binary_search, jump_search,
     selection_sort, insertion_sort, intro_sort, Backend)
 
-from pydatastructs.linear_data_structures.algorithms import shell_sort
+from pydatastructs.linear_data_structures.algorithms import shell_sort, radix_sort
 from pydatastructs.utils.raises_util import raises
-import random
+import random, pytest
 
 def _test_common_sort(sort, *args, **kwargs):
     random.seed(1000)
@@ -436,3 +436,24 @@ def test_shell_sort():
     input_data = [-5, 3, -10, 7, 0, -2]
     expected = [-10, -5, -2, 0, 3, 7]
     assert shell_sort(input_data) == expected
+
+def test_radix_sort():
+    assert radix_sort([]) == []
+
+    assert radix_sort([42]) == [42]
+
+    input_data = [1, 2, 3, 4, 5]
+    expected = [1, 2, 3, 4, 5]
+    assert radix_sort(input_data) == expected
+
+    input_data = [5, 4, 3, 2, 1]
+    expected = [1, 2, 3, 4, 5]
+    assert radix_sort(input_data) == expected
+
+    input_data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3]
+    expected = [1, 1, 2, 3, 3, 4, 5, 5, 6, 9]
+    assert radix_sort(input_data) == expected
+
+    input_data = [1000, 10, 100, 1, 10000]
+    expected = [1, 10, 100, 1000, 10000]
+    assert radix_sort(input_data) == expected

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -5,9 +5,8 @@ from pydatastructs import (
     cocktail_shaker_sort, quick_sort, longest_common_subsequence, is_ordered,
     upper_bound, lower_bound, longest_increasing_subsequence, next_permutation,
     prev_permutation, bubble_sort, linear_search, binary_search, jump_search,
-    selection_sort, insertion_sort, intro_sort, Backend)
+    selection_sort, insertion_sort, intro_sort, shell_sort, radix_sort, Backend)
 
-from pydatastructs.linear_data_structures.algorithms import shell_sort, radix_sort
 from pydatastructs.utils.raises_util import raises
 import random, pytest
 

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -416,43 +416,7 @@ def test_jump_search():
     _test_common_search(jump_search, backend=Backend.CPP)
 
 def test_shell_sort():
-    assert shell_sort([]) == []
-
-    assert shell_sort([42]) == [42]
-
-    input_data = [1, 2, 3, 4, 5]
-    expected = [1, 2, 3, 4, 5]
-    assert shell_sort(input_data) == expected
-
-    input_data = [5, 4, 3, 2, 1]
-    expected = [1, 2, 3, 4, 5]
-    assert shell_sort(input_data) == expected
-
-    input_data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3]
-    expected = [1, 1, 2, 3, 3, 4, 5, 5, 6, 9]
-    assert shell_sort(input_data) == expected
-
-    input_data = [-5, 3, -10, 7, 0, -2]
-    expected = [-10, -5, -2, 0, 3, 7]
-    assert shell_sort(input_data) == expected
+    _test_common_sort(shell_sort)
 
 def test_radix_sort():
-    assert radix_sort([]) == []
-
-    assert radix_sort([42]) == [42]
-
-    input_data = [1, 2, 3, 4, 5]
-    expected = [1, 2, 3, 4, 5]
-    assert radix_sort(input_data) == expected
-
-    input_data = [5, 4, 3, 2, 1]
-    expected = [1, 2, 3, 4, 5]
-    assert radix_sort(input_data) == expected
-
-    input_data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3]
-    expected = [1, 1, 2, 3, 3, 4, 5, 5, 6, 9]
-    assert radix_sort(input_data) == expected
-
-    input_data = [1000, 10, 100, 1, 10000]
-    expected = [1, 10, 100, 1000, 10000]
-    assert radix_sort(input_data) == expected
+    _test_common_sort(radix_sort)

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -5,7 +5,7 @@ from pydatastructs import (
     cocktail_shaker_sort, quick_sort, longest_common_subsequence, is_ordered,
     upper_bound, lower_bound, longest_increasing_subsequence, next_permutation,
     prev_permutation, bubble_sort, linear_search, binary_search, jump_search,
-    selection_sort, insertion_sort, intro_sort, shell_sort, radix_sort, Backend)
+    selection_sort, insertion_sort, intro_sort, shell_sort, radix_sort, reverse_array, Backend)
 
 from pydatastructs.utils.raises_util import raises
 import random
@@ -200,15 +200,15 @@ def test_is_ordered():
         assert output == expected_result
 
         expected_result = True
-        arr3 = ODA(int, [0, -1, -2, -3, -4, 4])
-        output = is_ordered(arr3, start=1, end=4,
+        arr2 = ODA(int, [0, -1, -2, -3, -4, 4])
+        output = is_ordered(arr2, start=1, end=4,
                             comp=lambda u, v: u > v, **kwargs)
         assert output == expected_result
 
         expected_result = True
-        arr4 = DODA(int, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-        arr4.delete(0)
-        output = is_ordered(arr4, **kwargs)
+        arr3 = DODA(int, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+        arr3.delete(0)
+        output = is_ordered(arr3, **kwargs)
         assert output == expected_result
 
     _test_inner_ordered()
@@ -227,13 +227,13 @@ def test_upper_bound():
     expected_result = 2
     assert expected_result == output
 
-    arr3 = ODA(int, [6, 6, 7, 8, 9])
-    output = upper_bound(arr3, 5, start=2, end=4)
+    arr2 = ODA(int, [6, 6, 7, 8, 9])
+    output = upper_bound(arr2, 5, start=2, end=4)
     expected_result = 2
     assert expected_result == output
 
-    arr4 = ODA(int, [3, 4, 4, 6])
-    output = upper_bound(arr4, 5, start=1, end=3)
+    arr3 = ODA(int, [3, 4, 4, 6])
+    output = upper_bound(arr3, 5, start=1, end=3)
     expected_result = 3
     assert expected_result == output
 
@@ -242,13 +242,13 @@ def test_upper_bound():
     expected_result = 5
     assert expected_result == output
 
-    arr6 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
-    output = upper_bound(arr6, 2, start=2, comp=lambda x, y: x > y)
+    arr4 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
+    output = upper_bound(arr4, 2, start=2, comp=lambda x, y: x > y)
     expected_result = 8
     assert expected_result == output
 
-    arr7 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
-    output = upper_bound(arr7, 9, start=3, end=7, comp=lambda x, y: x > y)
+    arr5 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
+    output = upper_bound(arr5, 9, start=3, end=7, comp=lambda x, y: x > y)
     expected_result = 3
     assert expected_result == output
 
@@ -270,13 +270,13 @@ def test_lower_bound():
     expected_result = 3
     assert expected_result == output
 
-    arr3 = ODA(int, [6, 6, 7, 8, 9])
-    output = lower_bound(arr3, 5, end=3)
+    arr2 = ODA(int, [6, 6, 7, 8, 9])
+    output = lower_bound(arr2, 5, end=3)
     expected_result = 0
     assert expected_result == output
 
-    arr4 = ODA(int, [3, 4, 4, 4])
-    output = lower_bound(arr4, 5)
+    arr3 = ODA(int, [3, 4, 4, 4])
+    output = lower_bound(arr3, 5)
     expected_result = 4
     assert expected_result == output
 
@@ -285,13 +285,13 @@ def test_lower_bound():
     expected_result = 5
     assert expected_result == output
 
-    arr6 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
-    output = lower_bound(arr6, 2, start=4, comp=lambda x, y: x > y)
+    arr4 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
+    output = lower_bound(arr4, 2, start=4, comp=lambda x, y: x > y)
     expected_result = 8
     assert expected_result == output
 
-    arr7 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
-    output = lower_bound(arr7, 9, end=5, comp=lambda x, y: x > y)
+    arr5 = ODA(int, [7, 6, 6, 6, 6, 5, 4, 3])
+    output = lower_bound(arr5, 9, end=5, comp=lambda x, y: x > y)
     expected_result = 0
     assert expected_result == output
 
@@ -313,13 +313,13 @@ def test_longest_increasing_subsequence():
     expected_result = [-1, 2, 3, 7, 9, 10]
     assert str(expected_result) == str(output)
 
-    arr3 = ODA(int, [6, 6, 6, 19, 9])
-    output = longest_increasing_subsequence(arr3)
+    arr2 = ODA(int, [6, 6, 6, 19, 9])
+    output = longest_increasing_subsequence(arr2)
     expected_result = [6, 9]
     assert str(expected_result) == str(output)
 
-    arr4 = ODA(int, [5, 4, 4, 3, 3, 6, 6, 8])
-    output = longest_increasing_subsequence(arr4)
+    arr3 = ODA(int, [5, 4, 4, 3, 3, 6, 6, 8])
+    output = longest_increasing_subsequence(arr3)
     expected_result = [3, 6, 8]
     assert str(expected_result) == str(output)
 
@@ -420,3 +420,26 @@ def test_shell_sort():
 
 def test_radix_sort():
     _test_common_sort(radix_sort)
+
+def test_reverse_array():
+    arr1 = DynamicOneDimensionalArray(int, [1, 2, 3, 4, 5])
+    reverse_array(arr1)
+    assert arr1._data == [5, 4, 3, 2, 1]
+
+    arr2 = DynamicOneDimensionalArray(int, [1, 2, 3])
+    original_data = arr2._data.copy()
+    reverse_array(arr2, start=2, end=1)
+    assert arr2._data == original_data
+
+    arr3 = DynamicOneDimensionalArray(int, [42])
+    reverse_array(arr3, start=0, end=0)
+    assert arr3._data == [42]
+
+    arr4 = DynamicOneDimensionalArray(int, [5, -3, 1, -10, 7])
+    reverse_array(arr4, start=1, end=3)
+    assert arr4._data == [5, -10, 1, -3, 7]
+
+    arr5 = OneDimensionalArray(int, 5)
+    arr5._data = [1, 2, 3, 4, 5]
+    reverse_array(arr5, start=1, end=3)
+    assert arr5._data == [1, 4, 3, 2, 5]

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -7,6 +7,7 @@ from pydatastructs import (
     prev_permutation, bubble_sort, linear_search, binary_search, jump_search,
     selection_sort, insertion_sort, intro_sort, Backend)
 
+from pydatastructs.linear_data_structures.algorithms import shell_sort
 from pydatastructs.utils.raises_util import raises
 import random
 
@@ -414,3 +415,24 @@ def test_binary_search():
 def test_jump_search():
     _test_common_search(jump_search)
     _test_common_search(jump_search, backend=Backend.CPP)
+
+def test_shell_sort():
+    assert shell_sort([]) == []
+
+    assert shell_sort([42]) == [42]
+
+    input_data = [1, 2, 3, 4, 5]
+    expected = [1, 2, 3, 4, 5]
+    assert shell_sort(input_data) == expected
+
+    input_data = [5, 4, 3, 2, 1]
+    expected = [1, 2, 3, 4, 5]
+    assert shell_sort(input_data) == expected
+
+    input_data = [3, 1, 4, 1, 5, 9, 2, 6, 5, 3]
+    expected = [1, 1, 2, 3, 3, 4, 5, 5, 6, 9]
+    assert shell_sort(input_data) == expected
+
+    input_data = [-5, 3, -10, 7, 0, -2]
+    expected = [-10, -5, -2, 0, 3, 7]
+    assert shell_sort(input_data) == expected

--- a/pydatastructs/linear_data_structures/tests/test_algorithms.py
+++ b/pydatastructs/linear_data_structures/tests/test_algorithms.py
@@ -8,7 +8,7 @@ from pydatastructs import (
     selection_sort, insertion_sort, intro_sort, shell_sort, radix_sort, Backend)
 
 from pydatastructs.utils.raises_util import raises
-import random, pytest
+import random
 
 def _test_common_sort(sort, *args, **kwargs):
     random.seed(1000)


### PR DESCRIPTION
## Fixes #664
This pull request introduces a reverse method to the pydatastructs library for linear data structures, starting with an implementation for the Array class in `linear_data_structures/algorithms.py` The addition enhances the library's sequence manipulation capabilities by providing an in-place reversal operation for arrays, addressing a common need in algorithmic problem-solving and data processing.

In the future, I will be adding similar reverse methods for other linear data structures:

- LinkedList: Reverse the direction of pointers in-place.

- Stack: Pop and push elements to create a reversed stack, potentially returning a new stack.

- Queue: Reverse the order of elements, potentially returning a new queue.