### PR TITLE
Use clang on Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,7 @@ jobs:
           clang-cl --version
 
       - name: Build package
+        shell: cmd /C call {0}
         run: |
           set CC=clang-cl
           set CXX=clang-cl


### PR DESCRIPTION
## Summary
- install clang on the Windows CI runner
- set `CC`/`CXX` to `clang-cl` and use `-std=c++17`

## Testing
- `python -m pip install -r requirements.txt`
- `python -m pip install -r docs/requirements.txt`
- `python scripts/build/install.py`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6886147478d0832d9bb0c88d0fdcd1b8